### PR TITLE
CISSSO Integration (Quality of Life Updates to analysis.py)

### DIFF
--- a/scripts/qa_patients/OMG_CISSSO_Test.py
+++ b/scripts/qa_patients/OMG_CISSSO_Test.py
@@ -161,12 +161,11 @@ def main():
         if normalisation == "ref_roi": film.apply_factor_from_roi()             # Normalize based on roi dose
         
         gamma_analysis(film, scan_name, path_analyse, doseTA = 3, distTA = 3, show_results = True, 
-                      threshold = threshold, norm_val = None, film_filt = film_filt, pickle_save = pickle_save)
+                      threshold = threshold, norm_val = norm_val, film_filt = film_filt, pickle_save = pickle_save)
         gamma_analysis(film, scan_name, path_analyse, doseTA = 2, distTA = 2, show_results = True, 
-                      threshold = threshold, norm_val = None, film_filt = film_filt, pickle_save = pickle_save)
+                      threshold = threshold, norm_val = norm_val, film_filt = film_filt, pickle_save = pickle_save)
         gamma_analysis(film, scan_name, path_analyse, doseTA = 1, distTA = 1, show_results = True,
-                      threshold = threshold, norm_val = None, film_filt = film_filt, pickle_save = pickle_save)
-
+                      threshold = threshold, norm_val = norm_val, film_filt = film_filt, pickle_save = pickle_save)
         return
         
 def gamma_analysis(dose2analysis, filebase, path_analyse, doseTA = 3, distTA = 3, show_results = True, 

--- a/scripts/qa_patients/OMG_CISSSO_Test.py
+++ b/scripts/qa_patients/OMG_CISSSO_Test.py
@@ -1,0 +1,200 @@
+# -*- coding: utf-8 -*-
+""" OMG_Tiff2Analysis.py
+    - More Details to Come
+"""
+__author__ = "Peter Truong"
+__contact__ = "petertruong.cissso@ssss.gouv.qc.ca"
+__version__ = "04 octobre 2023"
+
+from omg_dosimetry import analysis, tiff2dose
+import os, sys, ctypes, pickle
+import tkinter as tk
+from tkinter import filedialog
+root = tk.Tk()                              # Declare root (top-level instance)
+root.withdraw()                             # Show only dialog without any other GUI elements by hiding root window
+root.attributes("-topmost", True)           # Top-level window display priority
+import pydicom
+import matplotlib.pyplot as plt
+plt.ion()           # Interactive Mode: ON
+
+### Parameter Initialization
+info = dict(author = "PT", 
+            unit = "CL1", 
+            film_lot = "EBT-3 C2",
+            scanner_id = "Epson 10000XL", 
+            date_exposed = "2023-10-02",
+            date_scanned = "2023-10-03",
+            wait_time = "24h", 
+            notes = "Patient QA")
+
+### Look-up Table (LUT) Path Initialization
+landscape = False
+LatCor = True
+if landscape: # Landscape Orientation
+    lut_file = (r"\\SVWCT2Out0455\Phys\Répertoires communs\Radiotherapie Externe\Film_QA\Calibration_LUT"
+                r"\2022-10-04\C2_3Gy_72dpi_landscape.pkl")
+else: # Portrait Orientation    
+    # if LatCor: lut_file = (r"\\SVWCT2Out0455\Phys\Répertoires communs\Radiotherapie Externe\Film_QA\Calibration_LUT"
+    #                        r"\2023-09-12 (C2 LatCor)\C2_3Gy_LUT_LatCor_9MeV_2023-09-12.pkl")
+    # else: lut_file = (r"\\SVWCT2Out0455\Phys\Répertoires communs\Radiotherapie Externe\Film_QA\Calibration_LUT"
+    #                   r"\2023-09-12 (C2 LatCor)\Sans LatCor\C2_3Gy_LUT_9MeV_2023-09-12.pkl")
+    if LatCor: lut_file = (r"\\SVWCT2Out0455\Phys\Répertoires communs\Radiotherapie Externe\Film_QA"
+                           r"\379302 CRIC Test\2023-09-12 (C2 LatCor)\C2_3Gy_LUT_LatCor_9MeV_2023-09-12.pkl")
+    else: lut_file = (r"\\SVWCT2Out0455\Phys\Répertoires communs\Radiotherapie Externe\Film_QA"
+                      r"\379302 CRIC Test\2023-09-12 (C2 LatCor)\C2_3Gy_LUT_LatCor_9MeV_2023-09-12_sansLatCor.pkl")
+    
+
+### Tiff2Dose Parameters
+tiff_2_dose, tiff_2_dose_show_pdf = 1, 0
+clip = 600
+if landscape: rot_scan = 1
+else: rot_scan = 0
+
+### Tiff2Analysis Parameters
+dose_2_analysis, dose_2_analysis_show_pdf = 1, 0
+analysis_publish_pdf = False
+pickle_save = False
+crop_film = 1
+flipLR, flipUD = 1, 0
+rot90 = 0
+
+shift_x, shift_y = 0, 0
+markers_center = None
+#markers_center = [0, 0, 45]         # Based on DICOM coordinates in mm (LR, IS, AP)
+
+#normalisation = 1.00
+#normalisation = "ref_roi"
+normalisation = "norm_film"
+norm_film_MU = 300
+
+### Normalization Reference (Eclipse)
+norm_film_ref_MU = 300
+norm_film_ref_dose = 315.5          # qaphys_dosimetrie_filmGaf/Calibration/C2 (average diagonal profile in Eclipse)
+norm_film_dose = norm_film_MU / norm_film_ref_MU * norm_film_ref_dose
+
+### Gamma Analysis Parameters
+threshold = 0.10
+norm_val = "max"
+film_filt = 3
+
+### Path Initialization
+path_base = r"\\SVWCT2Out0455\Phys\Répertoires communs\Radiotherapie Externe\Film_QA"
+
+### Script Functionality
+def main():
+    
+    ### Scanned Film Image Selection
+    path_scan = filedialog.askopenfilename(parent = root, title = "Select Scanned Film to Convert To Dose", 
+                                           initialdir = path_base)
+    if not path_scan:
+        print("No image selected. Exiting Script... ")
+        sys.exit()
+    scan_name = os.path.basename(os.path.splitext(path_scan)[0])
+    
+    ### Scanned Normalization Film Image Selection
+    response = ctypes.windll.user32.MessageBoxW(0, "Was the normalization film scanned separate? If so, would you " \
+                                                "wish to proceed with selecting the normalization film scan?", 
+                                                "Normalization Film Selection", 0x1000 | 0x20 | 0x3)
+    if response == 6: 
+        path_normFilm = filedialog.askopenfilename(parent = root, title = "Select Scanned Normalization Film " \
+                                                   "to Convert To Dose")
+        normFilm_name = os.path.basename(os.path.splitext(path_normFilm)[0])
+    elif response == 2: 
+        print("Cancel option was selected. Exiting Script..." )
+        sys.exit()
+    else: path_normFilm = None
+    ### Reference Eclipse Dose Plan File Selection
+    path_doseEclipse = filedialog.askopenfilename(parent = root, title = "Select Reference Eclipse Dose Plan File", 
+                                                  filetypes = [("Eclipse Dose Plane DICOM File", ".dcm")])
+    if not path_doseEclipse:
+        print("No image selected. Exiting Script... ")
+        sys.exit()
+    
+    ### DICOM Information Extract
+    try: 
+        ds = pydicom.dcmread(path_doseEclipse)
+        patient_ID, plan_ID = ds.PatientID, ds.DoseComment
+    except:
+        print("Invalid DICOM file selected. ")
+        sys.exit()
+    
+    ### Initialize Folder Structure
+#    path_plan = os.path.join(path_base, patient_ID, plan_ID)
+    path_plan = os.path.dirname(os.path.dirname(path_doseEclipse))
+    path_doseFilm, path_analyse = os.path.join(path_plan, "DoseFilm"), os.path.join(path_plan, "Analyse")
+    
+    ### Create Folders
+#    if not (os.path.exists(path_plan)): os.makedirs(path_plan)             # Should exist if taken from os.path.dirname
+    if not os.path.exists(path_doseFilm): os.makedirs(path_doseFilm)     
+    if not os.path.exists(path_analyse): os.makedirs(path_analyse)  
+    
+    ### Create Tiff2Dose
+    if tiff_2_dose:
+        gaf = tiff2dose.Gaf(path = path_scan, lut_file = lut_file, info = info, clip = clip, rot90 = rot_scan)
+        gaf_dose_tif = os.path.join(path_doseFilm, scan_name) + ".tif"
+        gaf.dose_opt.save(gaf_dose_tif)
+        gaf.publish_pdf(gaf_dose_tif[:-4] + ".pdf", open_file = tiff_2_dose_show_pdf)
+        if pickle_save: pickle.dump(gaf, open(gaf_dose_tif[:-4] + ".pkl", "wb"))
+        if path_normFilm:
+            gaf_norm = tiff2dose.Gaf(path = path_normFilm, lut_file = lut_file, info = info, clip = clip, 
+                                     rot90 = rot_scan)
+            gaf_norm_dose_tif = os.path.join(path_doseFilm, normFilm_name) + ".tif"
+            gaf_norm.dose_opt.save(gaf_norm_dose_tif)
+            gaf_norm.publish_pdf(gaf_norm_dose_tif[:-4] + ".pdf", open_file = tiff_2_dose_show_pdf)
+            if pickle_save: pickle.dump(gaf_norm, open(gaf_norm_dose_tif[:-4] + ".pkl", "wb"))
+        
+    ### Analyze
+    if dose_2_analysis:
+        if path_normFilm:
+            film = analysis.DoseAnalysis(film_dose = gaf_dose_tif, ref_dose = path_doseEclipse, 
+                                        norm_film_dose = gaf_norm_dose_tif, flipLR = flipLR, flipUD = flipUD, 
+                                        rot90 = rot90)
+        else:
+            film = analysis.DoseAnalysis(film_dose = gaf_dose_tif, ref_dose = path_doseEclipse, flipLR = flipLR, 
+                                        flipUD = flipUD, rot90 = rot90)
+        
+        if normalisation == "norm_film": film.apply_factor_from_roi(norm_dose = norm_film_dose)
+        if crop_film: film.crop_film()
+        film.register(shift_x = shift_x, shift_y = shift_y, threshold = 10, register_using_gradient = True, 
+                      markers_center = markers_center)
+        if normalisation == "ref_roi": film.apply_factor_from_roi()             # Normalize based on roi dose
+        
+        gamma_analysis(film, scan_name, path_analyse, doseTA = 3, distTA = 3, show_results = True, 
+                      threshold = threshold, norm_val = None, film_filt = film_filt, pickle_save = pickle_save)
+        gamma_analysis(film, scan_name, path_analyse, doseTA = 2, distTA = 2, show_results = True, 
+                      threshold = threshold, norm_val = None, film_filt = film_filt, pickle_save = pickle_save)
+        gamma_analysis(film, scan_name, path_analyse, doseTA = 1, distTA = 1, show_results = True,
+                      threshold = threshold, norm_val = None, film_filt = film_filt, pickle_save = pickle_save)
+
+        return
+        
+def gamma_analysis(dose2analysis, filebase, path_analyse, doseTA = 3, distTA = 3, show_results = True, 
+                  threshold = 0.10, norm_val = "max", film_filt = 3, pickle_save = True):
+    filename = "{}_Facteur{:.2f}_Filtre{}_Gamma{}%-{}mm_report.pdf".format(filebase, 
+                dose2analysis.film_dose_factor, film_filt, doseTA, distTA)
+    fileout = os.path.join(path_analyse, filename)
+    print("Analyse en cours...")
+    dose2analysis.gamma_analysis(doseTA = doseTA, distTA = distTA, threshold = threshold, norm_val = norm_val, 
+                          film_filt = film_filt, local_gamma = False)
+    print("")
+    print("======================= Gamma {}/{} ============================".format(doseTA, distTA))
+    print("      Gammma {}%/{}mm: Taux de passage={:.2f}%; Moyenne={:.2f}".format(doseTA, distTA, 
+          dose2analysis.GammaMap.passRate, dose2analysis.GammaMap.mean))   
+    print("==============================================================")
+    if show_results: dose2analysis.show_results()
+    if analysis_publish_pdf: 
+        dose2analysis.publish_pdf(fileout, open_file = dose_2_analysis_show_pdf, show_hist = True, 
+                                  show_pass_hist = True, show_varDistTA = False, show_var_DoseTA = False, 
+                                  x = None, y = None)
+    if pickle_save: pickle.dump(dose2analysis, open(fileout[:-4] + ".pkl", "wb"))
+    
+def load_pickle(file_path = None, show_results = True):
+    if not file_path: file_path = filedialog.askopenfilename(parent = root, filetypes = [("pickle", ".pkl")])
+        
+    pkl = pickle.load(open(file_path, "rb"))
+    if show_results: pkl.show_results()
+    
+    return pkl
+    
+if __name__ == "__main__":
+    main()

--- a/scripts/qa_patients/OMG_CISSSO_Test.py
+++ b/scripts/qa_patients/OMG_CISSSO_Test.py
@@ -4,7 +4,7 @@
 """
 __author__ = "Peter Truong"
 __contact__ = "petertruong.cissso@ssss.gouv.qc.ca"
-__version__ = "04 octobre 2023"
+__version__ = "27 novembre 2023"
 
 from omg_dosimetry import analysis, tiff2dose
 import os, sys, ctypes, pickle
@@ -19,11 +19,11 @@ plt.ion()           # Interactive Mode: ON
 
 ### Parameter Initialization
 info = dict(author = "PT", 
-            unit = "CL1", 
+            unit = "CL3", 
             film_lot = "EBT-3 C2",
             scanner_id = "Epson 10000XL", 
-            date_exposed = "2023-10-02",
-            date_scanned = "2023-10-03",
+            date_exposed = "2023-11-16",
+            date_scanned = "2023-11-17",
             wait_time = "24h", 
             notes = "Patient QA")
 
@@ -39,9 +39,9 @@ else: # Portrait Orientation
     # else: lut_file = (r"\\SVWCT2Out0455\Phys\Répertoires communs\Radiotherapie Externe\Film_QA\Calibration_LUT"
     #                   r"\2023-09-12 (C2 LatCor)\Sans LatCor\C2_3Gy_LUT_9MeV_2023-09-12.pkl")
     if LatCor: lut_file = (r"\\SVWCT2Out0455\Phys\Répertoires communs\Radiotherapie Externe\Film_QA"
-                           r"\379302 CRIC Test\2023-09-12 (C2 LatCor)\C2_3Gy_LUT_LatCor_9MeV_2023-09-12.pkl")
+                           r"\CRIC Testing\2023-09-12 (C2 LatCor)\C2_3Gy_LUT_LatCor_9MeV_2023-09-12.pkl")
     else: lut_file = (r"\\SVWCT2Out0455\Phys\Répertoires communs\Radiotherapie Externe\Film_QA"
-                      r"\379302 CRIC Test\2023-09-12 (C2 LatCor)\C2_3Gy_LUT_LatCor_9MeV_2023-09-12_sansLatCor.pkl")
+                      r"\CRIC Testing\2023-09-12 (C2 LatCor)\Sans LatCor\C2_3Gy_LUT_9MeV_2023-09-12.pkl")
     
 
 ### Tiff2Dose Parameters
@@ -52,8 +52,8 @@ else: rot_scan = 0
 
 ### Tiff2Analysis Parameters
 dose_2_analysis, dose_2_analysis_show_pdf = 1, 0
-analysis_publish_pdf = False
-pickle_save = False
+analysis_publish_pdf = True
+pickle_save = True
 crop_film = 1
 flipLR, flipUD = 1, 0
 rot90 = 0

--- a/scripts/qa_patients/OMG_CISSSO_Test.py
+++ b/scripts/qa_patients/OMG_CISSSO_Test.py
@@ -105,7 +105,8 @@ def main():
     else: path_normFilm = None
     ### Reference Eclipse Dose Plan File Selection
     path_doseEclipse = filedialog.askopenfilename(parent = root, title = "Select Reference Eclipse Dose Plan File", 
-                                                  filetypes = [("Eclipse Dose Plane DICOM File", ".dcm")])
+                                                  filetypes = [("Eclipse Dose Plane DICOM File", ".dcm")], 
+                                                  initialdir = os.path.dirname(os.path.dirname(path_scan)))
     if not path_doseEclipse:
         print("No image selected. Exiting Script... ")
         sys.exit()
@@ -173,7 +174,7 @@ def gamma_analysis(dose2analysis, filebase, path_analyse, doseTA = 3, distTA = 3
     filename = "{}_Facteur{:.2f}_Filtre{}_Gamma{}%-{}mm_report.pdf".format(filebase, 
                 dose2analysis.film_dose_factor, film_filt, doseTA, distTA)
     fileout = os.path.join(path_analyse, filename)
-    print("Analyse en cours...")
+    print("\nAnalyse en cours...")
     dose2analysis.gamma_analysis(doseTA = doseTA, distTA = distTA, threshold = threshold, norm_val = norm_val, 
                           film_filt = film_filt, local_gamma = False)
     print("")

--- a/scripts/qa_patients/OMG_CISSSO_Test.py
+++ b/scripts/qa_patients/OMG_CISSSO_Test.py
@@ -31,8 +31,10 @@ info = dict(author = "PT",
 landscape = False
 LatCor = True
 if landscape: # Landscape Orientation
-    lut_file = (r"\\SVWCT2Out0455\Phys\Répertoires communs\Radiotherapie Externe\Film_QA\Calibration_LUT"
-                r"\2022-10-04\C2_3Gy_72dpi_landscape.pkl")
+    # lut_file = (r"\\SVWCT2Out0455\Phys\Répertoires communs\Radiotherapie Externe\Film_QA\Calibration_LUT"
+    #             r"\2022-10-04\C2_3Gy_72dpi_landscape.pkl")
+    lut_file = (r"\\SVWCT2Out0455\Phys\Répertoires communs\Radiotherapie Externe\Film_QA\CRIC Testing"
+                r"\0001-Drolet_039086\C2_3Gy_72dpi_landscape_CRIC.pkl")
 else: # Portrait Orientation    
     # if LatCor: lut_file = (r"\\SVWCT2Out0455\Phys\Répertoires communs\Radiotherapie Externe\Film_QA\Calibration_LUT"
     #                        r"\2023-09-12 (C2 LatCor)\C2_3Gy_LUT_LatCor_9MeV_2023-09-12.pkl")
@@ -184,7 +186,7 @@ def gamma_analysis(dose2analysis, filebase, path_analyse, doseTA = 3, distTA = 3
     if show_results: dose2analysis.show_results()
     if analysis_publish_pdf: 
         dose2analysis.publish_pdf(fileout, open_file = dose_2_analysis_show_pdf, show_hist = True, 
-                                  show_pass_hist = True, show_varDistTA = False, show_var_DoseTA = False, 
+                                  show_pass_hist = True, show_varDistTA = False, show_varDoseTA = False, 
                                   x = None, y = None)
     if pickle_save: pickle.dump(dose2analysis, open(fileout[:-4] + ".pkl", "wb"))
     

--- a/scripts/tools/Analysis_Pickle.bat
+++ b/scripts/tools/Analysis_Pickle.bat
@@ -1,0 +1,5 @@
+cls
+@echo off
+echo Note: Analysis_Pickle requires some time to fully load. Please allow a few seconds (5) for graphical user interface to load. File/directory prompt may appear in background...
+echo Note 2: Command Prompt Window needs to be closed as an additional step when exiting out of script/figure
+"\\SVWCT2Out0455\Phys\R‚pertoires communs\Compilations Python\WPy64-310111 - Version OMG Film (CRIC)\python-3.10.11.amd64\python.exe" -i "\\SVWCT2Out0455\Phys\R‚pertoires individuels\Peter Truong\GITEA\OMG Film Dosimetry (CRIC)\scripts\tools\Analysis_Pickle.py"

--- a/scripts/tools/Analysis_Pickle.py
+++ b/scripts/tools/Analysis_Pickle.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Oct 27 15:53:30 2022
+
+@author: Peter Truong (CISSSO)
+@version: 05 decembre 2023
+"""
+
+import pickle, bz2
+import tkinter as tk
+from tkinter import filedialog
+root = tk.Tk()                              # Declare root (top-level instance)
+root.withdraw()                             # Show only dialog without any other GUI elements by hiding root window
+root.attributes("-topmost", True)           # Top-level window display priority
+
+def main(file_path = None, show_results = True):
+    if not file_path: file_path = filedialog.askopenfilename(parent = root, filetypes = [("Pickle File", ".pkl")])
+    print("\nLoading .pkl file: {}...".format(file_path))
+    
+    try: analysis = pickle.load(bz2.open(file_path, "rb"))  # Whether or not .pkl was compressed or not.
+    except: analysis = pickle.load(open(file_path, "rb"))
+    
+    if show_results: analysis.show_results(show = True)
+    
+    return analysis
+            
+if __name__ == "__main__":
+    pkl = main()

--- a/src/omg_dosimetry/analysis.py
+++ b/src/omg_dosimetry/analysis.py
@@ -720,7 +720,7 @@ class DoseAnalysis():
         fig, ((ax1,ax2),(ax3,ax4),(ax5,ax6)) = plt.subplots(3,2, figsize=(10, 8))
         fig.tight_layout()
         axes = [ax1,ax2,ax3,ax4,ax5,ax6]
-        fig.canvas.set_window_title("Facteur{:.2f}_Filtre{}_Gamma{}%-{}mm".format(self.film_dose_factor, self.film_filt, self.doseTA, self.distTA))
+        fig.canvas.manager.set_window_title("Facteur{:.2f}_Filtre{}_Gamma{}%-{}mm".format(self.film_dose_factor, self.film_filt, self.doseTA, self.distTA))
         
         max_dose_comp = np.percentile(self.ref_dose.array,[98])[0].round(decimals=-1)
         clim = [0, max_dose_comp]   
@@ -829,7 +829,7 @@ class DoseAnalysis():
         plt.show()
         
         self.wait = True
-        while self.wait: plt.pause(5)
+        while self.wait: plt.pause(5)   # To consider 1 second vs. 5 seconds
         plt.close(self.fig)  # Before with self.rs=RectangleSelector(drawtype='box')... This would help close object instance (avoids extra figure instances open)
         return
         

--- a/src/omg_dosimetry/analysis.py
+++ b/src/omg_dosimetry/analysis.py
@@ -80,7 +80,6 @@ class DoseAnalysis():
 
     ref_dose_sum : bool, optional
         If True, all all planar dose files found in the ref_dose folder will be summed together.
-        
     """
 
     def __init__(self, film_dose=None, ref_dose=None, norm_film_dose = None, film_dose_factor=1, ref_dose_factor=1, flipLR=False, flipUD=False, rot90=0, ref_dose_sum=False):
@@ -117,7 +116,7 @@ class DoseAnalysis():
         if film_dose_factor is not None:
             self.film_dose_factor = film_dose_factor
             self.film_dose.array = self.film_dose.array * self.film_dose_factor
-            print("Applied film normalisation factor = {}".format(self.film_dose_factor))
+            print("\mApplied film normalisation factor = {}".format(self.film_dose_factor))
 
     def apply_ref_factor(self, ref_dose_factor = None):
         """ Apply a normalisation factor to reference dose. """
@@ -148,7 +147,7 @@ class DoseAnalysis():
         """
         
         self.norm_dose = norm_dose      
-        msg = 'Factor from ROI: Click and drag to draw an ROI manually. Press ''enter'' when finished.'
+        msg = '\nFactor from ROI: Click and drag to draw an ROI manually. Press ''enter'' when finished.'
         self.roi_xmin, self.roi_xmax = [], []
         self.roi_ymin, self.roi_ymax = [], []
 
@@ -205,7 +204,7 @@ class DoseAnalysis():
         
         self.norm_dose = norm_dose
         self.norm_roi_size = norm_roi_size
-        msg = 'Factor from normalisation film: Double-click at the center of the film markers. Press enter when done'
+        msg = '\nFactor from normalisation film: Double-click at the center of the film markers. Press enter when done'
         self.roi_center = []
         self.roi_xmin, self.roi_xmax = [], []
         self.roi_ymin, self.roi_ymax = [], []
@@ -244,7 +243,7 @@ class DoseAnalysis():
         """  Brings up an interactive plot, where the user must define 
              a rectangle ROI that will be used to crop the film.
         """     
-        msg = 'Crop film: Click and drag to draw an ROI. Press ''enter'' when finished.'
+        msg = '\nCrop film: Click and drag to draw an ROI. Press ''enter'' when finished.'
         
         self.fig = plt.figure()
         ax = plt.gca()  
@@ -326,7 +325,6 @@ class DoseAnalysis():
             random_subset : float (>=0, <=1), optional
                 Used to only calculate a random subset fraction of the reference grid, to speed up calculation.
                 Default is None
-
         """
         self.doseTA, self.distTA = doseTA, distTA
         self.film_filt, self.threshold, self.norm_val = film_filt, threshold, norm_val        
@@ -365,7 +363,7 @@ class DoseAnalysis():
     
     def computeGamma(self, doseTA=2, distTA=2, threshold=0.1, norm_val=None, local_gamma=False, max_gamma=None, random_subset=None):
         """Compute Gamma (using pymedphys.gamma) """
-        print("Computing {}% {} mm Gamma...".format(doseTA, distTA))
+        print("\nComputing {}%/{} mm Gamma...".format(doseTA, distTA))
         # error checking
         if not is_close(self.film_dose.dpi, self.ref_dose.dpi, delta=3):
             raise AttributeError("The image DPIs to not match: {:.2f} vs. {:.2f}".format(self.film_dose.dpi, self.ref_dose.dpi))
@@ -675,20 +673,20 @@ class DoseAnalysis():
         """ Display an interactive figure showing the results of a gamma analysis.
             The figure contains 6 axis, which are, from left to right and top to bottom:
             Film dose, reference dose, gamma map, relative error, x profile and y profile.
+            
             Parameters
             ----------
             fig : matplotlib.pyplot figure object, optional
                 Figure in which to plot the graph.
                 If None, a new figure is made.
                 Default is None
+            
             x, y : int, optional
                 Initial x/y coordinates of the profiles.
                 If None, profile will be at image center.
                 Default is None
         """
         a = None
-        film_fileName=os.path.basename(self.film_dose.path)
-        ref_fileName=os.path.basename(self.ref_dose.path)
         
         if x is None: self.prof_x = np.floor(self.ref_dose.shape[1] / 2).astype(int)
         elif x == 'max':
@@ -705,10 +703,10 @@ class DoseAnalysis():
         fig.canvas.manager.set_window_title("Facteur{:.2f}_Filtre{}_Gamma{}%-{}mm".format(self.film_dose_factor, self.film_filt, self.doseTA, self.distTA))
         
         max_dose_comp = np.percentile(self.ref_dose.array,[98])[0].round(decimals=-1)
-        clim = [0, max_dose_comp]   
+        clim = [0, max_dose_comp]
 
-        self.film_dose.plotCB(ax1, clim=clim, title='Film dose ({})'.format(film_fileName))
-        self.ref_dose.plotCB(ax2, clim=clim, title='Reference dose ({})'.format(ref_fileName))
+        self.film_dose.plotCB(ax1, clim=clim, title='Film dose ({})'.format(os.path.basename(self.film_dose.path)))
+        self.ref_dose.plotCB(ax2, clim=clim, title='Reference dose ({})'.format(os.path.basename(self.ref_dose.path)))
         self.GammaMap.plotCB(ax3, clim=[0,2], cmap='bwr', title='Gamma map ({:.2f}% pass; {:.2f} mean)'.format(self.GammaMap.passRate, self.GammaMap.mean))
         ax3.set_facecolor('k')
         min_value = max(-20, np.percentile(self.DiffMap.array,[1])[0].round(decimals=0))
@@ -750,29 +748,34 @@ class DoseAnalysis():
             
             self.show_profiles(axes,x=self.prof_x, y=self.prof_y)    
             plt.gcf().canvas.draw_idle()
-        else: print('Zoom/pan is currently selected.\nUnable to set profile when this tool has been selected.\n')
+        else: print('\nZoom/pan is currently selected.\nUnable to set profile when this tool has been selected.')
         
     def register(self, shift_x=0, shift_y=0, threshold=10, register_using_gradient=False, markers_center=None, rot=0):
         """ Starts the registration procedure between film and reference dose.
+            
             Parameters
             ----------
             shift_x / shift_y : float, optional
             Apply a known shift [mm] in the x/y direction between reference dose and film dose. 
             Used if there is a known shift between the registration point in the reference image and the film image.
             Default is 0
+            
             threshold : int, optional
             Threshold value [cGy] used in detecting film edges for auto-cropping.
             Default is 10
+            
             register_using_gradient : bool, optional
             Determine if the registration results (overlay of film/ref dose) will be displayed 
             after applying a sobel filter to improve visibility of strong dose gradients.
             Default is False
+            
             markers_center : list of 3 floats, optional
             Coordinates [mm] in the reference dose corresponding to the marks intersection on the film (R-L, I-S, P-A).
             It will be used to align the reference point on the film (given by the intersection of the two lines
             determined by the four marks made on the edges of the film) to an absolute position in the reference dose.
             If None, the film reference point will be positioned to the center of the reference dose.
             Default is None
+            
             rot : float, optional
             Apply a known rotation [degrees] between reference dose and film dose. 
             Used if the markers on the reference image are known to be not perfectly aligned
@@ -785,8 +788,7 @@ class DoseAnalysis():
         self.markers_center = markers_center
         if threshold > 0 :
             self.film_dose.crop_edges(threshold=threshold)
-        print('Please double-click on each marker. Press ''enter'' when done')
-        print('Keyboard shortcuts: Right arrow = Rotate 90 degrees; Left arrow = Flip horizontally; Up arrow = Flip vertically')
+        
         self.film_dose.plot()
         self.select_markers()
         self.tune_registration()
@@ -798,6 +800,8 @@ class DoseAnalysis():
         self.fig = plt.gcf()
         self.markers = []
         ax = plt.gca()
+        print('\nPlease double-click on each marker. Press ''enter'' when done')
+        print('Keyboard shortcuts: Right arrow = Rotate 90 degrees; Left arrow = Flip horizontally; Up arrow = Flip vertically')
         ax.set_title('Marker 1 = ; Marker 2 = ; Marker 3 = ; Marker 4 = ')
         self.fig.canvas.mpl_connect('button_press_event', self.onclick)
         self.cid = self.fig.canvas.mpl_connect('key_press_event', self.ontype)
@@ -821,15 +825,19 @@ class DoseAnalysis():
         """ This function is called by self.onclick() and self.ontype() when 
             self.markers need to be plotted onto figure
         """
+        if len(self.markers) == 0: 
+            print("\nplot_markers was called with no markers found in self.markers")
+            return
+        
         ax = plt.gca()
-        l = 20          # Length of crosshair/marker
-        for i in range(0, len(self.markers)):
-            ax.plot((self.markers[i][0]-l,self.markers[i][0]+l),(self.markers[i][1],self.markers[i][1]),'w', linewidth=1)
-            ax.plot((self.markers[i][0],self.markers[i][0]),(self.markers[i][1]-l,self.markers[i][1]+l),'w', linewidth=1)
-            if i == 0: ax.set_title('Marker 1 = {}; Marker 2 =  ; Marker 3 =  ; Marker 4 =  '.format(self.markers[0]))
-            elif i == 1: ax.set_title('Marker 1 = {}; Marker 2 = {}; Marker 3 =  ; Marker 4 =  '.format(self.markers[0], self.markers[1]))
-            elif i == 2: ax.set_title('Marker 1 = {}; Marker 2 = {}; Marker 3 = {}; Marker 4 =  '.format(self.markers[0], self.markers[1], self.markers[2]))
-            elif i == 3: ax.set_title('Marker 1 = {}; Marker 2 = {}; Marker 3 = {}; Marker 4 = {}'.format(self.markers[0], self.markers[1], self.markers[2], self.markers[3]))
+        l = 20                              # Length of crosshair/marker
+        m_i = len(self.markers) - 1         # last marker indice
+        ax.plot((self.markers[m_i][0]-l,self.markers[m_i][0]+l),(self.markers[m_i][1],self.markers[m_i][1]),'w', linewidth=1)
+        ax.plot((self.markers[m_i][0],self.markers[m_i][0]),(self.markers[m_i][1]-l,self.markers[m_i][1]+l),'w', linewidth=1)
+        if m_i == 0: ax.set_title('Marker 1 = {}; Marker 2 =  ; Marker 3 =  ; Marker 4 =  '.format(self.markers[0]))
+        elif m_i == 1: ax.set_title('Marker 1 = {}; Marker 2 = {}; Marker 3 =  ; Marker 4 =  '.format(self.markers[0], self.markers[1]))
+        elif m_i == 2: ax.set_title('Marker 1 = {}; Marker 2 = {}; Marker 3 = {}; Marker 4 =  '.format(self.markers[0], self.markers[1], self.markers[2]))
+        elif m_i == 3: ax.set_title('Marker 1 = {}; Marker 2 = {}; Marker 3 = {}; Marker 4 = {}'.format(self.markers[0], self.markers[1], self.markers[2], self.markers[3]))
         plt.gcf().canvas.draw_idle()
         
     def ontype(self, event):
@@ -840,9 +848,8 @@ class DoseAnalysis():
             """ This subfunction will reset self.markers and add marker text/title
                 to the figure
             """
-            print('')
-            if reason == "change": print('Film dose array changed...')
-            elif reason == "less": print('{} markers were selected when 4 were expected...'.format(len(self.markers)))
+            if reason == "change": print('\nFilm dose array has updated...')
+            elif reason == "less": print('\n{} markers were selected when 4 were expected...'.format(len(self.markers)))
             print('Please start over...')
             print('Please double-click on each marker. Press ''enter'' when done')
             self.markers = []
@@ -873,14 +880,17 @@ class DoseAnalysis():
                 max_x = np.floor(self.film_dose.array.shape[1]).astype(int)
                 max_y = np.floor(self.film_dose.array.shape[0]).astype(int)
                 self.markers = [[max_x/2, 0], [max_x, max_y/2], [max_x/2, max_y], [0, max_y/2]]
-                print("No markers selected.\nCenter of film dose array selected for markers.\nAdjust registration.")
+                print("\nNo markers selected.\nCenter of film dose array selected for markers."
+                      "\nAdjust registration as needed.")
             elif len(self.markers) != 4:
                 ax.clear()
                 self.film_dose.plot(ax=ax)
                 reset_markers("less")
                 fig.canvas.draw_idle()
             
-            if len(self.markers) == 4:    
+            if len(self.markers) == 4:
+                print("Marker 1: {}; Marker 2: {}; Marker 3: {}; Marker 4 = {}.".format(self.markers[0], self.markers[1],
+                                                                                        self.markers[2], self.markers[3]))
                 self.fig.canvas.mpl_disconnect(self.cid)
                 self.move_iso_center()
                 self.remove_rotation()
@@ -1003,7 +1013,7 @@ class DoseAnalysis():
         (self.film_dose, self.ref_dose) = equate_images(self.film_dose, self.ref_dose)
         self.film_dose.path = film_dose_path
         self.ref_dose.path = ref_dose_path
-        print('Fine tune registration using keyboard if needed. Arrow keys = move; ctrl+left/right = rotate. Press enter when done.')
+        print('\nFine tune registration using keyboard if needed. Arrow keys = move; ctrl+left/right = rotate. Press enter when done.')
         self.fig = plt.figure()
         ax = plt.gca()
         self.cid = self.fig.canvas.mpl_connect('key_press_event', self.reg_ontype)
@@ -1124,10 +1134,13 @@ class DoseAnalysis():
         ----------
         filename : str
             The path and/or filename to save the PDF report as; must end in ".pdf".
+        
         author : str, optional
             The person who analyzed the image.
+        
         unit : str, optional
             The machine unit name or other identifier (e.g. serial number).
+        
         notes : str, list of strings, optional
             If a string, adds it as a line of text in the PDf report.
             If a list of strings, each string item is printed on its own line. Useful for writing multiple sentences.
@@ -1189,12 +1202,13 @@ class DoseAnalysis():
             The direction of the profile.
             Either 'x' (horizontal) or 'y' (vertical).
             Default is 'x'.
+        
         side : str, optional
             The side on the profile that will be matched.
             Either 'left' or 'right'.
             Default is left. 
         """
-        msg = 'Use left/right keyboard arrows to move profile and fit on ' + side + ' side. Press Enter when done.'
+        msg = '\nUse left/right keyboard arrows to move profile and fit on ' + side + ' side. Press Enter when done.'
         print(msg)
         self.offset = 0
         self.direction = direction
@@ -1241,10 +1255,10 @@ def line_intersection(line1, line2):
         line1 : tuple 
             Coordinates of 2 points defining the first line
             line1 = ((x1,y1),(x2,y2))
+        
         line1 : tuple 
             Coordinates of 2 points defining the second line
             line1 = ((x1,y1),(x2,y2)) 
-
     """
     xdiff = (line1[0][0] - line1[1][0], line2[0][0] - line2[1][0])
     ydiff = (line1[0][1] - line1[1][1], line2[0][1] - line2[1][1])
@@ -1271,7 +1285,7 @@ def load_dose(filename):
         return pickle.load(input)
 
 def load_analysis(filename):
-    print("Loading analysis file {}...".format(filename))
+    print("\nLoading analysis file {}...".format(filename))
     try:
         file = bz2.open(filename, 'rb')
         analysis = pickle.load(file)
@@ -1282,7 +1296,7 @@ def load_analysis(filename):
     return analysis
 
 def save_analysis(analysis, filename, use_compression=True):
-    print("Saving analysis file as {}...".format(filename))
+    print("\nSaving analysis file as {}...".format(filename))
     if use_compression:
         file = bz2.open(filename, 'wb')
     else:

--- a/src/omg_dosimetry/analysis.py
+++ b/src/omg_dosimetry/analysis.py
@@ -881,8 +881,6 @@ class DoseAnalysis():
                 reset_markers("less")
                 fig.canvas.draw_idle()
             
-            for i in self.markers:
-                print(i)
             if len(self.markers) == 4:    
                 self.fig.canvas.mpl_disconnect(self.cid)
                 self.move_iso_center()
@@ -962,7 +960,7 @@ class DoseAnalysis():
                 y0 = self.ref_dose.sizeY - int(np.around(y_pos_mm * self.ref_dose.dpmm))
 
             self.ref_dose.move_pixel_to_center(x0, y0)
-
+            
     def remove_rotation(self):
         """ Rotates the film around the center so that left/right
             and top/bottom markers are horizontally and vertically aligned.  

--- a/src/omg_dosimetry/analysis.py
+++ b/src/omg_dosimetry/analysis.py
@@ -15,13 +15,12 @@ Features:
 Written by Jean-Francois Cabana
 Version 2023-07-27
 Written by Jean-Francois Cabana, copyright 2018
-Modified by Peter Truong: 2023-11-27
+Modified by Peter Truong: 2023-11-29
 """
 
 import numpy as np
 import scipy.ndimage.filters as spf
 import copy
-import matplotlib
 import matplotlib.pyplot as plt
 import os
 from pylinac.core.utilities import is_close
@@ -179,8 +178,8 @@ class DoseAnalysis():
         self.cid = self.fig.canvas.mpl_connect('key_press_event', self.apply_factor_from_roi_press_enter)
         
         self.wait = True
-        while self.wait: plt.pause(1)   # To consider 1 second vs. 5 seconds
-        plt.close(self.fig)  # Before with self.rs=RectangleSelector(drawtype='box')... This would help close object instance (avoids extra figure instances open)
+        while self.wait: plt.pause(1)
+        plt.close(self.fig)
         return
 
     def apply_factor_from_roi_press_enter(self, event):
@@ -199,7 +198,6 @@ class DoseAnalysis():
             
             if hasattr(self, "rs"): del self.rs                
             self.fig.canvas.mpl_disconnect(self.cid)
-            # plt.close(self.fig)   # Commented out as issue (outside of Spyder IDE) causes crash due to missing self.fig pointer/object
             self.wait = False
             return
 
@@ -225,7 +223,7 @@ class DoseAnalysis():
         self.fig.canvas.mpl_connect('button_press_event', self.onclick_norm)
         self.cid = self.fig.canvas.mpl_connect('key_press_event', self.apply_factor_from_roi_press_enter)         
         self.wait = True
-        while self.wait: plt.pause(1)   # To consider 1 second vs. 5 seconds
+        while self.wait: plt.pause(1)
         plt.close(self.fig)
         return
             
@@ -267,8 +265,8 @@ class DoseAnalysis():
         self.rs = RectangleSelector(ax, select_box, useblit=True, button=[1], minspanx=5, minspany=5, spancoords='pixels', interactive=True)  
         self.cid = self.fig.canvas.mpl_connect('key_press_event', self.crop_film_press_enter)
         self.wait = True
-        while self.wait: plt.pause(1)      # To consider 1 second vs. 5 seconds
-        plt.close(self.fig)  # Before with self.rs=RectangleSelector(drawtype='box')... This would help close object instance (avoids extra figure instances open)
+        while self.wait: plt.pause(1)
+        plt.close(self.fig)
         return
         
     def crop_film_press_enter(self, event):
@@ -285,7 +283,6 @@ class DoseAnalysis():
             self.film_dose.crop(bottom,'bottom')  
             
             self.fig.canvas.mpl_disconnect(self.cid)
-            # plt.close(self.fig)      # Commented out as issue (outside of Spyder IDE) causes crash due to missing self.fig pointer/object
             self.wait = False
             return
         
@@ -370,7 +367,7 @@ class DoseAnalysis():
     def computeGamma(self, doseTA=2, distTA=2, threshold=0.1, norm_val=None, local_gamma=False, max_gamma=None, random_subset=None):
         """Compute Gamma (using pymedphys.gamma) """
         print("Computing {}% {} mm Gamma...".format(doseTA, distTA))
-#       # error checking
+        # error checking
         if not is_close(self.film_dose.dpi, self.ref_dose.dpi, delta=3):
             raise AttributeError("The image DPIs to not match: {:.2f} vs. {:.2f}".format(self.film_dose.dpi, self.ref_dose.dpi))
         same_x = is_close(self.film_dose.shape[1], self.ref_dose.shape[1], delta=1.1)
@@ -400,16 +397,6 @@ class DoseAnalysis():
         
         # Compute the number of pixels to analyze
         if random_subset: random_subset = int(len(dose_reference[dose_reference >= threshold].flat) * random_subset)
-
-        # # set coordinates (convert pixel coordinates to mm [distTA units])    # Keeping for reference (CISSSO-Side)
-        # x, y = ref_dose.shape[0], ref_dose.shape[1]
-        # x_coord, y_coord =  list(range(0,x)), list(range(0,y)) 
-        # x_coord, y_coord = [pixel / self.ref_dose.dpmm for pixel in x_coord], [pixel / self.ref_dose.dpmm for pixel in y_coord]
-        # coords_reference, coords_evaluation = (x_coord, y_coord), (x_coord, y_coord)
-        
-        # # Gamma computation and set maps
-        # gamma = pymedphys.gamma(coords_reference, ref_dose.array, coords_evaluation, film_dose.array, doseTA, distTA, 
-        #                         threshold*100, local_gamma = local_gamma, max_gamma = 2.0)
         
         # Gamma computation and set maps
         gamma = pymedphys.gamma(axes_reference, dose_reference, axes_evaluation, dose_evaluation, doseTA, distTA, threshold*100,
@@ -649,7 +636,6 @@ class DoseAnalysis():
                 film_prof = film[position[1],:]
                 ref_prof = ref[position[1],:]
                 v_ligne = position[0]
-#            x_axis = (np.array(range(0, len(film_prof))) / self.film_dose.dpmm).tolist()
             
         elif profile == 'y':
             if position is None:
@@ -659,8 +645,7 @@ class DoseAnalysis():
             else: 
                 film_prof = film[:,position[0]]
                 ref_prof = ref[:,position[0]]
-                v_ligne = position[1]
-#            x_axis = (np.array(range(0, len(film_prof))) / self.film_dose.dpmm).tolist()            
+                v_ligne = position[1]           
         
         x_axis = np.array(range(0, len(film_prof))).tolist()
         y_max = max(np.concatenate((film_prof, ref_prof)))
@@ -680,7 +665,6 @@ class DoseAnalysis():
                 if profile == 'x': title='Profile horizontal (y={})'.format(position)
                 if profile == 'y': title='Profile vertical (x={})'.format(position)
         ax.set_title(title)
-#        ax.set_xlabel('Position (mm)')
         ax.set_xlabel('Pixel Position')
         ax.set_ylabel('Dose (cGy)')
         
@@ -707,17 +691,14 @@ class DoseAnalysis():
         film_fileName=os.path.basename(self.film_dose.path)
         ref_fileName=os.path.basename(self.ref_dose.path)
         
-        if x is None:
-            x = np.floor(self.ref_dose.shape[1] / 2).astype(int)
+        if x is None: self.prof_x = np.floor(self.ref_dose.shape[1] / 2).astype(int)
         elif x == 'max':
             a = np.unravel_index(self.ref_dose.array.argmax(), self.ref_dose.array.shape)
-            x = a[1]
-        if y is None:
-            y = np.floor(self.ref_dose.shape[0] / 2).astype(int)
+            self.prof_x = a[1]
+        if y is None: self.prof_y = np.floor(self.ref_dose.shape[0] / 2).astype(int)
         elif y == 'max':
-            if a is None:
-                a = np.unravel_index(self.ref_dose.array.argmax(), self.ref_dose.array.shape)
-            y = a[0]
+            if a is None: a = np.unravel_index(self.ref_dose.array.argmax(), self.ref_dose.array.shape)
+            self.prof_y = a[0]
          
         fig, ((ax1,ax2),(ax3,ax4),(ax5,ax6)) = plt.subplots(3,2, figsize=(10, 8))
         fig.tight_layout()
@@ -735,7 +716,7 @@ class DoseAnalysis():
         max_value = min(20, np.percentile(self.DiffMap.array,[99])[0].round(decimals=0))
         clim = [min_value, max_value]    
         self.RelError.plotCB(ax4, cmap='jet', clim=clim, title='Relative Error (%) (RMSE={:.2f})'.format(self.DiffMap.RMSE))
-        self.show_profiles(axes, x=x, y=y)
+        self.show_profiles(axes, x=self.prof_x, y=self.prof_y)
         
         fig.canvas.mpl_connect('button_press_event', lambda event: self.set_profile(event, axes))
         
@@ -761,22 +742,16 @@ class DoseAnalysis():
         """ This function is called by show_results to draw dose profiles
             on mouse click (if cursor is not set to zoom or pan).
         """
-        try:
-            zooming_panning = ( plt.gcf().canvas.cursor().shape() != 0 ) # 0 is the arrow, which means we are not zooming or panning.
-        except:
-            zooming_panning = False
-        if zooming_panning: 
-            return
-        if event.inaxes in axes[0:4]:
-            if event.button == 1:
-                x = int(event.xdata)
-                y = int(event.ydata)
-                self.show_profiles(axes,x=x, y=y)
-                plt.gcf().canvas.draw_idle()
-        # x = int(event.xdata)  # Keeping previous version for CISSSO application
-        # y = int(event.ydata)
-        # self.show_profiles(axes,x=x, y=y)
-        # plt.gcf().canvas.draw_idle()
+        if event.button == 1 and plt.gcf().canvas.cursor().shape() == 0:   # 0 is the arrow, which means we are not zooming or panning.
+            if event.inaxes in axes[0:4]:
+                self.prof_x = int(event.xdata)
+                self.prof_y = int(event.ydata)
+            elif event.inaxes == axes[4]: self.prof_x = int(event.xdata)
+            elif event.inaxes == axes[5]: self.prof_y = int(event.xdata)
+            
+            self.show_profiles(axes,x=self.prof_x, y=self.prof_y)    
+            plt.gcf().canvas.draw_idle()
+        else: print('Zoom/pan is currently selected.\nUnable to set profile when this tool has been selected.\n')
         
     def register(self, shift_x=0, shift_y=0, threshold=10, register_using_gradient=False, markers_center=None, rot=0):
         """ Starts the registration procedure between film and reference dose.
@@ -831,8 +806,8 @@ class DoseAnalysis():
         plt.show()
         
         self.wait = True
-        while self.wait: plt.pause(1)  # To consider 1 second vs. 5 seconds
-        plt.close(self.fig)  # Before with self.rs=RectangleSelector(drawtype='box')... This would help close object instance (avoids extra figure instances open)
+        while self.wait: plt.pause(1)
+        plt.close(self.fig)
         return
         
     def onclick(self, event):
@@ -895,23 +870,26 @@ class DoseAnalysis():
             reset_markers()
             fig.canvas.draw_idle()
         elif event.key == 'enter':
-            if len(self.markers) != 4:
+            if len(self.markers) == 0:
+                max_x = np.floor(self.film_dose.array.shape[1]).astype(int)
+                max_y = np.floor(self.film_dose.array.shape[0]).astype(int)
+                self.markers = [[max_x/2, 0], [max_x, max_y/2], [max_x/2, max_y], [0, max_y/2]]
+                print("No markers selected.\nCenter of film dose array selected for markers.\nAdjust registration.")
+            elif len(self.markers) != 4:
                 ax.clear()
                 self.film_dose.plot(ax=ax)
                 reset_markers("less")
                 fig.canvas.draw_idle()
-            else:
+            
+            for i in self.markers:
+                print(i)
+            if len(self.markers) == 4:    
                 self.fig.canvas.mpl_disconnect(self.cid)
-                # plt.close(self.fig)   # Closing too early before self.wait is done causes issues.
-                
                 self.move_iso_center()
                 self.remove_rotation()
-                if self.ref_dose is not None:
-                    self.apply_shifts_ref()
-                if self.rot:
-                    self.film_dose.rotate(self.rot)
+                if self.ref_dose is not None: self.apply_shifts_ref()
+                if self.rot: self.film_dose.rotate(self.rot)
                 self.wait = False
-                # self.tune_registration()  # Better performed separately in register function (not reliant on event)
             return
                 
     def move_iso_center(self):
@@ -982,8 +960,6 @@ class DoseAnalysis():
                 y_pos_mm = y_marker - y_corner
                 x0 = int(np.around(x_pos_mm * self.ref_dose.dpmm))
                 y0 = self.ref_dose.sizeY - int(np.around(y_pos_mm * self.ref_dose.dpmm))
-                # x0 = x_corner + (self.ref_dose.sizeX / 2 * self.ref_dose.metadata.PixelSpacing[0])        # Idea, but not working for Eclipse case
-                # y0 = y_corner - (self.ref_dose.sizeY / 2 * self.ref_dose.metadata.PixelSpacing[1])
 
             self.ref_dose.move_pixel_to_center(x0, y0)
 
@@ -1045,8 +1021,8 @@ class DoseAnalysis():
         self.show_registration(ax=ax)
 
         self.wait = True
-        while self.wait: plt.pause(1)   # To consider 1 second vs. 5 seconds
-        plt.close(self.fig)  # Before with self.rs=RectangleSelector(drawtype='box')... This would help close object instance (avoids extra figure instances open)
+        while self.wait: plt.pause(1)
+        plt.close(self.fig)
         return
         
     def show_registration(self, ax=None, cmap='bwr'):
@@ -1114,7 +1090,6 @@ class DoseAnalysis():
             fig.canvas.draw_idle()
         if event.key == 'enter':
             self.fig.canvas.mpl_disconnect(self.cid)
-            # plt.close(self.fig)   # Closing too early before self.wait is done causes issues.
             self.wait = False
             return
             
@@ -1234,7 +1209,7 @@ class DoseAnalysis():
         self.fig = plt.gcf()
         self.cid = self.fig.canvas.mpl_connect('key_press_event', self.move_profile_ontype)
         self.wait = True
-        while self.wait: plt.pause(1)   # To consider 1 second vs. 5 seconds
+        while self.wait: plt.pause(1)
         plt.close(self.fig)
         return
                 

--- a/src/omg_dosimetry/analysis.py
+++ b/src/omg_dosimetry/analysis.py
@@ -116,7 +116,7 @@ class DoseAnalysis():
         if film_dose_factor is not None:
             self.film_dose_factor = film_dose_factor
             self.film_dose.array = self.film_dose.array * self.film_dose_factor
-            print("\mApplied film normalisation factor = {}".format(self.film_dose_factor))
+            print("\nApplied film normalisation factor = {}".format(self.film_dose_factor))
 
     def apply_ref_factor(self, ref_dose_factor = None):
         """ Apply a normalisation factor to reference dose. """

--- a/src/omg_dosimetry/analysis.py
+++ b/src/omg_dosimetry/analysis.py
@@ -179,7 +179,7 @@ class DoseAnalysis():
         self.cid = self.fig.canvas.mpl_connect('key_press_event', self.apply_factor_from_roi_press_enter)
         
         self.wait = True
-        while self.wait: plt.pause(5)   # To consider 1 second vs. 5 seconds
+        while self.wait: plt.pause(1)   # To consider 1 second vs. 5 seconds
         plt.close(self.fig)  # Before with self.rs=RectangleSelector(drawtype='box')... This would help close object instance (avoids extra figure instances open)
         return
 
@@ -225,7 +225,9 @@ class DoseAnalysis():
         self.fig.canvas.mpl_connect('button_press_event', self.onclick_norm)
         self.cid = self.fig.canvas.mpl_connect('key_press_event', self.apply_factor_from_roi_press_enter)         
         self.wait = True
-        while self.wait: plt.pause(5)
+        while self.wait: plt.pause(1)   # To consider 1 second vs. 5 seconds
+        plt.close(self.fig)
+        return
             
     def onclick_norm(self, event):
         ax = plt.gca()
@@ -265,7 +267,7 @@ class DoseAnalysis():
         self.rs = RectangleSelector(ax, select_box, useblit=True, button=[1], minspanx=5, minspany=5, spancoords='pixels', interactive=True)  
         self.cid = self.fig.canvas.mpl_connect('key_press_event', self.crop_film_press_enter)
         self.wait = True
-        while self.wait: plt.pause(5)      # To consider 1 second vs. 5 seconds
+        while self.wait: plt.pause(1)      # To consider 1 second vs. 5 seconds
         plt.close(self.fig)  # Before with self.rs=RectangleSelector(drawtype='box')... This would help close object instance (avoids extra figure instances open)
         return
         
@@ -822,14 +824,14 @@ class DoseAnalysis():
         self.fig = plt.gcf()
         self.markers = []
         ax = plt.gca()
-        ax.set_title('Marker 1 =  ; Marker 2 =  ; Marker 3 =  ; Marker 4 =  ')
+        ax.set_title('Marker 1 = ; Marker 2 = ; Marker 3 = ; Marker 4 = ')
         self.fig.canvas.mpl_connect('button_press_event', self.onclick)
         self.cid = self.fig.canvas.mpl_connect('key_press_event', self.ontype)
-        cursor = Cursor(ax, useblit=True, color='white', linewidth=1)
+        plt.cursor = Cursor(ax, useblit=True, color='white', linewidth=1)
         plt.show()
         
         self.wait = True
-        while self.wait: plt.pause(5)   # To consider 1 second vs. 5 seconds
+        while self.wait: plt.pause(1)  # To consider 1 second vs. 5 seconds
         plt.close(self.fig)  # Before with self.rs=RectangleSelector(drawtype='box')... This would help close object instance (avoids extra figure instances open)
         return
         
@@ -837,59 +839,67 @@ class DoseAnalysis():
         """ This function is called by self.select_markers() to set the markers
             coordinates when the mouse is double-cliked.
         """
-        ax = plt.gca()
-        if event.dblclick:
-            l = 20
+        if event.dblclick and len(self.markers) < 4: 
             self.markers.append([int(event.xdata), int(event.ydata)])
-            if len(self.markers)==1:
-                ax.plot((self.markers[0][0]-l,self.markers[0][0]+l),(self.markers[0][1],self.markers[0][1]),'w', linewidth=1)
-                ax.plot((self.markers[0][0],self.markers[0][0]),(self.markers[0][1]-l,self.markers[0][1]+l),'w', linewidth=1)
-                ax.set_title('Marker 1 = {}; Marker 2 =  ; Marker 3 =  ; Marker 4 =  '.format(self.markers[0]))
-            if len(self.markers)==2:
-                ax.plot((self.markers[1][0]-l,self.markers[1][0]+l),(self.markers[1][1],self.markers[1][1]),'w', linewidth=1)
-                ax.plot((self.markers[1][0],self.markers[1][0]),(self.markers[1][1]-l,self.markers[1][1]+l),'w', linewidth=1)
-                ax.set_title('Marker 1 = {}; Marker 2 = {}; Marker 3 =  ; Marker 4 =  '.format(self.markers[0], self.markers[1]))
-            if len(self.markers)==3:
-                ax.plot((self.markers[2][0]-l,self.markers[2][0]+l),(self.markers[2][1],self.markers[2][1]),'w', linewidth=1)
-                ax.plot((self.markers[2][0],self.markers[2][0]),(self.markers[2][1]-l,self.markers[2][1]+l),'w', linewidth=1)
-                ax.set_title('Marker 1 = {}; Marker 2 = {}; Marker 3 = {}; Marker 4 =  '.format(self.markers[0], self.markers[1], self.markers[2]))
-            if len(self.markers)==4:
-                ax.plot((self.markers[3][0]-l,self.markers[3][0]+l),(self.markers[3][1],self.markers[3][1]),'w', linewidth=1)
-                ax.plot((self.markers[3][0],self.markers[3][0]),(self.markers[3][1]-l,self.markers[3][1]+l),'w', linewidth=1)
-                ax.set_title('Marker 1 = {}; Marker 2 = {}; Marker 3 = {}; Marker 4 = {}'.format(self.markers[0], self.markers[1], self.markers[2], self.markers[3]))
-            plt.gcf().canvas.draw_idle()
+            self.plot_markers()
+            
+    def plot_markers(self):
+        """ This function is called by self.onclick() and self.ontype() when 
+            self.markers need to be plotted onto figure
+        """
+        ax = plt.gca()
+        l = 20          # Length of crosshair/marker
+        for i in range(0, len(self.markers)):
+            ax.plot((self.markers[i][0]-l,self.markers[i][0]+l),(self.markers[i][1],self.markers[i][1]),'w', linewidth=1)
+            ax.plot((self.markers[i][0],self.markers[i][0]),(self.markers[i][1]-l,self.markers[i][1]+l),'w', linewidth=1)
+            if i == 0: ax.set_title('Marker 1 = {}; Marker 2 =  ; Marker 3 =  ; Marker 4 =  '.format(self.markers[0]))
+            elif i == 1: ax.set_title('Marker 1 = {}; Marker 2 = {}; Marker 3 =  ; Marker 4 =  '.format(self.markers[0], self.markers[1]))
+            elif i == 2: ax.set_title('Marker 1 = {}; Marker 2 = {}; Marker 3 = {}; Marker 4 =  '.format(self.markers[0], self.markers[1], self.markers[2]))
+            elif i == 3: ax.set_title('Marker 1 = {}; Marker 2 = {}; Marker 3 = {}; Marker 4 = {}'.format(self.markers[0], self.markers[1], self.markers[2], self.markers[3]))
+        plt.gcf().canvas.draw_idle()
         
     def ontype(self, event):
         """ This function is called by self.select_markers() to continue the registration
             process when "enter" is pressed on the keyboard.
         """
+        def reset_markers(reason = "change"):
+            """ This subfunction will reset self.markers and add marker text/title
+                to the figure
+            """
+            print('')
+            if reason == "change": print('Film dose array changed...')
+            elif reason == "less": print('{} markers were selected when 4 were expected...'.format(len(self.markers)))
+            print('Please start over...')
+            print('Please double-click on each marker. Press ''enter'' when done')
+            self.markers = []
+            ax.set_title('Marker 1 = ; Marker 2 = ; Marker 3 = ; Marker 4 = ')        
+            
         fig = plt.gcf()
         ax = plt.gca()
-        ax.clear()
         if event.key == 'right':
+            ax.clear()
             self.film_dose.array = np.rot90(self.film_dose.array, k=1)
             self.film_dose.plot(ax=ax)
+            reset_markers()
             fig.canvas.draw_idle()
-        if event.key == 'left':
+        elif event.key == 'left':
+            ax.clear()
             self.film_dose.array = np.fliplr(self.film_dose.array)
             self.film_dose.plot(ax=ax)
+            reset_markers()
             fig.canvas.draw_idle()
-        if event.key == 'up':
+        elif event.key == 'up':
+            ax.clear()
             self.film_dose.array = np.flipud(self.film_dose.array)
             self.film_dose.plot(ax=ax)
+            reset_markers()
             fig.canvas.draw_idle()
-        
-        if event.key == 'enter':
+        elif event.key == 'enter':
             if len(self.markers) != 4:
-                print('')
-                print('Please start over...')
-                print('{} markers were selected when 4 were expected...'.format(len(self.markers)))
-                print('Please double-click on each marker. Press ''enter'' when done')
-                self.markers = []
-                ax = plt.gca()
+                ax.clear()
                 self.film_dose.plot(ax=ax)
+                reset_markers("less")
                 fig.canvas.draw_idle()
-                ax.set_title('Marker 1 = ; Marker 2 = ; Marker 3 = ; Marker 4 = ')
             else:
                 self.fig.canvas.mpl_disconnect(self.cid)
                 # plt.close(self.fig)   # Closing too early before self.wait is done causes issues.
@@ -902,7 +912,7 @@ class DoseAnalysis():
                     self.film_dose.rotate(self.rot)
                 self.wait = False
                 # self.tune_registration()  # Better performed separately in register function (not reliant on event)
-                return
+            return
                 
     def move_iso_center(self):
         """ Register the film dose and reference dose by moving the reference
@@ -1035,7 +1045,7 @@ class DoseAnalysis():
         self.show_registration(ax=ax)
 
         self.wait = True
-        while self.wait: plt.pause(5)   # To consider 1 second vs. 5 seconds
+        while self.wait: plt.pause(1)   # To consider 1 second vs. 5 seconds
         plt.close(self.fig)  # Before with self.rs=RectangleSelector(drawtype='box')... This would help close object instance (avoids extra figure instances open)
         return
         
@@ -1224,7 +1234,9 @@ class DoseAnalysis():
         self.fig = plt.gcf()
         self.cid = self.fig.canvas.mpl_connect('key_press_event', self.move_profile_ontype)
         self.wait = True
-        while self.wait: plt.pause(5)
+        while self.wait: plt.pause(1)   # To consider 1 second vs. 5 seconds
+        plt.close(self.fig)
+        return
                 
     def move_profile_ontype(self, event):
         """ This function is called by self.get_profile_offset()
@@ -1248,7 +1260,6 @@ class DoseAnalysis():
         
         if event.key == 'enter':
             self.fig.canvas.mpl_disconnect(self.cid)
-            plt.close(self.fig)
             self.wait = False
             return self.offset
 

--- a/src/omg_dosimetry/analysis.py
+++ b/src/omg_dosimetry/analysis.py
@@ -14,7 +14,7 @@ Features:
     
 Written by Jean-Francois Cabana, copyright 2018
 Modified by Peter Truong (CISSSO)
-Version: 2023-11-30
+Version: 2023-12-06
 """
 
 import numpy as np
@@ -669,7 +669,7 @@ class DoseAnalysis():
             diff_prof = film_prof - ref_prof
             ax.plot(x_axis, diff_prof,'g-', linewidth=2)
     
-    def show_results(self, fig=None, x=None, y=None):
+    def show_results(self, fig=None, x=None, y=None, show = True):
         """ Display an interactive figure showing the results of a gamma analysis.
             The figure contains 6 axis, which are, from left to right and top to bottom:
             Film dose, reference dose, gamma map, relative error, x profile and y profile.
@@ -716,6 +716,7 @@ class DoseAnalysis():
         self.show_profiles(axes, x=self.prof_x, y=self.prof_y)
         
         fig.canvas.mpl_connect('button_press_event', lambda event: self.set_profile(event, axes))
+        if show: plt.show()
         
     def show_profiles(self, axes, x, y):
         """ This function is called by show_results and set_profile to draw dose profiles
@@ -733,7 +734,6 @@ class DoseAnalysis():
             ax.plot((x,x),(0,self.ref_dose.shape[0]),'w--', linewidth=1)
             ax.plot((0,self.ref_dose.shape[1]),(y,y),'w--', linewidth=1)
         plt.multi = MultiCursor(None, (axes[0],axes[1],axes[2],axes[3]), color='r', lw=1, horizOn=True)
-        plt.show()
         
     def set_profile(self, event, axes):
         """ This function is called by show_results to draw dose profiles
@@ -748,7 +748,7 @@ class DoseAnalysis():
             
             self.show_profiles(axes,x=self.prof_x, y=self.prof_y)    
             plt.gcf().canvas.draw_idle()
-        else: print('\nZoom/pan is currently selected.\nUnable to set profile when this tool has been selected.')
+        else: print('\nZoom/pan is currently selected.\nNote: Unable to set profile when this tool is active.')
         
     def register(self, shift_x=0, shift_y=0, threshold=10, register_using_gradient=False, markers_center=None, rot=0):
         """ Starts the registration procedure between film and reference dose.
@@ -1106,7 +1106,7 @@ class DoseAnalysis():
         kwargs
             Keyword arguments are passed to plt.savefig().
         """
-        self.show_results(x=x, y=y)
+        self.show_results(x=x, y=y, **kwargs)
         fig = plt.gcf()
         fig.savefig(filename)
         plt.close(fig)
@@ -1162,7 +1162,7 @@ class DoseAnalysis():
                ]
         canvas.add_text(text=text, location=(1, 25), font_size=10)
         data = io.BytesIO()
-        self.save_analyzed_image(data, x=x, y=y)
+        self.save_analyzed_image(data, x=x, y=y, show = False)
         canvas.add_image(image_data=data, location=(0.5, 3), dimensions=(19, 19))
         
         canvas.add_new_page()

--- a/src/omg_dosimetry/analysis.py
+++ b/src/omg_dosimetry/analysis.py
@@ -12,10 +12,9 @@ Features:
       pass rate vs dose to agreement (fixed distance to agreement)
     - Publish PDF report
     
-Written by Jean-Francois Cabana
-Version 2023-07-27
 Written by Jean-Francois Cabana, copyright 2018
-Modified by Peter Truong: 2023-11-29
+Modified by Peter Truong (CISSSO)
+Version: 2023-11-30
 """
 
 import numpy as np
@@ -924,10 +923,8 @@ class DoseAnalysis():
             self.ref_dose.sizeX = self.ref_dose.metadata.Columns
             self.ref_dose.sizeY = self.ref_dose.metadata.Rows
             self.ref_dose.orientation = self.ref_dose.metadata.SeriesDescription
-            # self.ref_dose.orientation = self.ref_dose.metadata.ImageOrientationPatient      # Does not rely on description for orientation
 
             if 'Transversal' in self.ref_dose.orientation:
-            # if self.ref_dose.orientation == [1, 0, 0, 0, 1, 0]:
                 x_corner = self.ref_dose.position[0]
                 y_corner = -1.0 * self.ref_dose.position[1]
                 x_marker = self.markers_center[0]
@@ -938,7 +935,6 @@ class DoseAnalysis():
                 y0 = int(np.around(y_pos_mm * self.ref_dose.dpmm))
 
             if 'Sagittal' in self.ref_dose.orientation:
-            # if self.ref_dose.orientation == [0, -1, 0, 0, 0, -1]:
                 x_corner = -1.0 * self.ref_dose.position[1]
                 y_corner = self.ref_dose.position[2]
                 x_marker = self.markers_center[2]
@@ -949,7 +945,6 @@ class DoseAnalysis():
                 y0 = self.ref_dose.sizeY - int(np.around(y_pos_mm * self.ref_dose.dpmm))
 
             if 'Coronal' in self.ref_dose.orientation:
-            # if self.ref_dose.orientation == [1, 0, 0, 0, 0, -1]:
                 x_corner = self.ref_dose.position[0]
                 y_corner = self.ref_dose.position[2]
                 x_marker = self.markers_center[0]

--- a/src/omg_dosimetry/calibration.py
+++ b/src/omg_dosimetry/calibration.py
@@ -22,7 +22,8 @@ Features:
 * Publish PDF report
     
 Written by Jean-Francois Cabana and Luis Alfonso Olivares Jimenez, copyright 2018
-version 2023-09-27
+Modified by Peter Truong (CISSSO)
+version 2023-11-17
 """
 
 from pylinac.core.profile import SingleProfile
@@ -472,6 +473,8 @@ class LUT:
                     dose = self.doses_corr[:,i]
                     # interpolate beam profile at each pixel location
                     profile = np.interp(self.lat_pos[i], self.profile[:,0], self.profile[:,1]) / 100  
+                    # profile = np.interp(self.lat_pos[i], self.profile[:,0], self.profile[:,1])  # If already converted (Eclipse case)
+                    
                     dose_corr = dose * profile
                     self.doses_corr[:,i] = dose_corr
             
@@ -657,7 +660,7 @@ class LUT:
                 ax1.plot(ydata,xdata,'o',color=colors[j-2])
                 ax1.plot(y,x,color=colors[j-2])  
         
-    def show_results(self, savefile):
+    def show_results(self, savefile = None):
         """ Display a summary of the results.
         """
         fig = plt.figure(figsize=(8, 8))
@@ -675,7 +678,7 @@ class LUT:
             self.plot_fit(i='mean', ax=ax3)
             self.plot_lateral_response(ax=(ax4,ax5,ax6))
             fig.tight_layout()
-            plt.savefig(savefile)
+            if savefile: plt.savefig(savefile)
             plt.show()
         else:
             ax1 = plt.subplot2grid((3, 2), (0, 0))
@@ -688,7 +691,7 @@ class LUT:
             ax3.set_xlabel('Dose (cGy)')
             ax3.set_ylabel('Normalized pixel value')
             fig.tight_layout()
-            plt.savefig(savefile)
+            if savefile: plt.savefig(savefile)
             plt.show()
  
     def plot_beam_profile(self, ax=None):
@@ -862,6 +865,20 @@ def get_profile(file):
         profile[i,1] = float(content[i][1].replace(',','.')) 
     profile = profile[profile[:, 0].argsort()]
     return profile
+
+# def get_profile(file):
+#     """ Adjustment for profile taken/formatted from Eclipse/CISSSO"""
+#     with open(file, "r") as f:
+#         reader = csv.reader(f, delimiter = "\t")
+#         profile = list(reader)
+#         profile[0][0] = profile[0][0][3:]       # Remove ï»¿ (BOM: Byte Order Mark)
+    
+#     ### Convert String to Float
+#     for i in range(0, len(profile)):
+#         profile[i][0] = float(profile[i][0]) * 10   # Convert cm to mm
+#         profile[i][1] = float(profile[i][1]) / 100  # Convert from percentage
+        
+#     return profile
         
 def load_lut_array(filename):
     return np.load(filename)

--- a/src/omg_dosimetry/calibration.py
+++ b/src/omg_dosimetry/calibration.py
@@ -23,7 +23,7 @@ Features:
     
 Written by Jean-Francois Cabana and Luis Alfonso Olivares Jimenez, copyright 2018
 Modified by Peter Truong (CISSSO)
-Version: 2023-11-30
+Version: 2023-12-06
 """
 
 from pylinac.core.profile import SingleProfile
@@ -272,7 +272,7 @@ class LUT:
         #lut.publish_pdf(filename=os.path.join(demo_path, outname +'_report.pdf'), open_file=True)            # Generate a PDF report
         save_lut(lut, filename=os.path.join(demo_path, outname + '.pkl'), use_compression=True)  # Save the LUT file. use_compression allows a reduction  
                                                                                                         # in file size by a factor of ~10, but slows down the operation.
-        lut.show_results(io.BytesIO())
+        lut.show_results(io.BytesIO(), show = True)
 
     def load_images(self,path,filt):
         """ Load all images in a folder. Average multiple copies of same image
@@ -659,7 +659,7 @@ class LUT:
                 ax1.plot(ydata,xdata,'o',color=colors[j-2])
                 ax1.plot(y,x,color=colors[j-2])  
         
-    def show_results(self, savefile = None):
+    def show_results(self, savefile = None, show = True):
         """ Display a summary of the results.
         """
         fig = plt.figure(figsize=(8, 8))
@@ -676,9 +676,6 @@ class LUT:
             self.plot_calibration_curves(mode='all',ax=ax3)
             self.plot_fit(i='mean', ax=ax3)
             self.plot_lateral_response(ax=(ax4,ax5,ax6))
-            fig.tight_layout()
-            if savefile: plt.savefig(savefile)
-            plt.show()
         else:
             ax1 = plt.subplot2grid((3, 2), (0, 0))
             ax2 = plt.subplot2grid((3, 2), (0, 1))
@@ -689,9 +686,10 @@ class LUT:
             ax3.set_title('Calibration curves')
             ax3.set_xlabel('Dose (cGy)')
             ax3.set_ylabel('Normalized pixel value')
-            fig.tight_layout()
-            if savefile: plt.savefig(savefile)
-            plt.show()
+        
+        fig.tight_layout()
+        if savefile: plt.savefig(savefile)
+        if show: plt.show()
  
     def plot_beam_profile(self, ax=None):
         """ Plot the beam profile.
@@ -760,7 +758,7 @@ class LUT:
         kwargs
             Keyword arguments are passed to plt.savefig().
         """
-        self.show_results(filename)
+        self.show_results(filename, **kwargs)
         fig = plt.gcf()
         fig.savefig(filename)
         plt.close(fig)
@@ -787,7 +785,7 @@ class LUT:
         title = 'Film Calibration Report'
         canvas = pdf.PylinacCanvas(filename, page_title=title, logo=Path(__file__).parent / 'OMG_Logo.png')
         data = io.BytesIO()
-        self.save_analyzed_image(data)
+        self.save_analyzed_image(data, show = False)
         canvas.add_image(image_data=data, location=(3, 3.5), dimensions=(15, 15))
         canvas.add_text(text='Film infos:', location=(1, 25.5), font_size=10)
         text = ['Author: {}'.format(self.info['author']),
@@ -891,7 +889,7 @@ def save_lut(lut, filename, use_compression=True):
         filename : str
             Complete path to file
         use_compression : boolean
-            Wether or not to use bz2 compression to reduce file size
+            Whether or not to use bz2 compression to reduce file size
     """
     
     print("Saving LUT file as {}...".format(filename))

--- a/src/omg_dosimetry/calibration.py
+++ b/src/omg_dosimetry/calibration.py
@@ -23,7 +23,7 @@ Features:
     
 Written by Jean-Francois Cabana and Luis Alfonso Olivares Jimenez, copyright 2018
 Modified by Peter Truong (CISSSO)
-version 2023-11-17
+Version: 2023-11-30
 """
 
 from pylinac.core.profile import SingleProfile
@@ -472,8 +472,7 @@ class LUT:
                 for i in range(self.npixel):
                     dose = self.doses_corr[:,i]
                     # interpolate beam profile at each pixel location
-                    profile = np.interp(self.lat_pos[i], self.profile[:,0], self.profile[:,1]) / 100  
-                    # profile = np.interp(self.lat_pos[i], self.profile[:,0], self.profile[:,1])  # If already converted (Eclipse case)
+                    profile = np.interp(self.lat_pos[i], self.profile[:,0], self.profile[:,1]) / 100
                     
                     dose_corr = dose * profile
                     self.doses_corr[:,i] = dose_corr
@@ -865,20 +864,6 @@ def get_profile(file):
         profile[i,1] = float(content[i][1].replace(',','.')) 
     profile = profile[profile[:, 0].argsort()]
     return profile
-
-# def get_profile(file):
-#     """ Adjustment for profile taken/formatted from Eclipse/CISSSO"""
-#     with open(file, "r") as f:
-#         reader = csv.reader(f, delimiter = "\t")
-#         profile = list(reader)
-#         profile[0][0] = profile[0][0][3:]       # Remove ï»¿ (BOM: Byte Order Mark)
-    
-#     ### Convert String to Float
-#     for i in range(0, len(profile)):
-#         profile[i][0] = float(profile[i][0]) * 10   # Convert cm to mm
-#         profile[i][1] = float(profile[i][1]) / 100  # Convert from percentage
-        
-#     return profile
         
 def load_lut_array(filename):
     return np.load(filename)

--- a/src/omg_dosimetry/imageRGB.py
+++ b/src/omg_dosimetry/imageRGB.py
@@ -1,7 +1,9 @@
 """This module holds classes for image loading and manipulation.
     Adapted from pylinac.core.image for multichannel format support
     by Jean-François Cabana.
-
+    
+    Modified by: Peter Truong
+    Version: 2023-12-05
 """
 import copy
 from collections import Counter
@@ -368,8 +370,7 @@ class BaseImage:
         fig.colorbar(cax, ax=ax)   
         ax.set_title(title)
         ax.axis('image')      
-        if show:
-            plt.show()
+        if show: plt.show(block = False)
         return cax
 
     # @value_accept(kind=('median', 'gaussian'))

--- a/src/omg_dosimetry/tiff2dose.py
+++ b/src/omg_dosimetry/tiff2dose.py
@@ -17,7 +17,7 @@ Features:
     - Publish PDF report
         
 Written by Jean-Francois Cabana, copyright 2018
-version 2023-07-27
+Edit par Peter Truong: 2023-10-05
 """
 
 import os
@@ -298,11 +298,12 @@ class Gaf:
         self.dose_b.plotCB(ax3,clim=clim, title='Blue channel dose')
         self.dose_m.plotCB(ax4,clim=clim, title='Mean channel dose')
         self.dose_rg.plotCB(ax5,clim=clim, title='Red+Green Average dose')
-        self.dose_consistency.plotCB(ax6, cmap='gray', title='Consistency')
+        self.dose_consistency.plotCB(ax6, clim = [0, np.percentile(self.dose_consistency.array, [99.5])[0]], cmap='gray', title='Consistency')
         self.dose_opt.plotCB(ax7,clim=clim, title='Multichannel optimized dose')
-        self.dose_opt_delta.plotCB(ax8, cmap='gray', title='Disturbance')
-        self.dose_opt_RE.plotCB(ax9, cmap='gray', title='Residuals')
-
+        self.dose_opt_delta.plotCB(ax8, clim = [np.percentile(self.dose_opt_delta.array, [0.5])[0], 
+                                                np.percentile(self.dose_opt_delta.array, [99.5])[0]], cmap='gray', title='Disturbance')
+        self.dose_opt_RE.plotCB(ax9, clim = [0, np.percentile(self.dose_opt_RE.array, [99.5])[0]], cmap='gray', title='Residuals')
+        
         fig.tight_layout()
         
     def save_analyzed_image(self, filename, **kwargs):
@@ -315,7 +316,6 @@ class Gaf:
         kwargs
             Keyword arguments are passed to plt.savefig().
         """
-        
         self.show_results()
         fig = plt.gcf()
         fig.savefig(filename)
@@ -340,7 +340,6 @@ class Gaf:
             Whether or not to open the PDF file after it is created.
             Default is False.
         """
-
         if filename is None:
             filename = os.path.join(self.path, 'Report.pdf')
         title='Film-to-Dose Report'

--- a/src/omg_dosimetry/tiff2dose.py
+++ b/src/omg_dosimetry/tiff2dose.py
@@ -18,7 +18,7 @@ Features:
         
 Written by Jean-Francois Cabana, copyright 2018
 Modified by Peter Truong (CISSSO)
-Version: 2023-11-30
+Version: 2023-12-06
 """
 
 import os
@@ -28,7 +28,7 @@ import matplotlib.pyplot as plt
 import pickle
 from pylinac.core import pdf
 import io
-from matplotlib.widgets  import RectangleSelector
+from matplotlib.widgets  import RectangleSelector, MultiCursor
 import webbrowser
 from pathlib import Path
 from .imageRGB import load, load_multiples
@@ -285,7 +285,7 @@ class Gaf:
         self.dose_rg = load((dose_r+dose_g)/2., dpi=self.img.dpi)  
         self.dose_consistency = load(((dose_r-dose_g)**2 + (dose_r-dose_b)**2 + (dose_b-dose_g)**2)**0.5, dpi=self.img.dpi)  
         
-    def show_results(self):
+    def show_results(self, show = True):
         """ Display a figure with the different converted dose maps and metrics.
         """
 
@@ -293,6 +293,7 @@ class Gaf:
         max_dose_opt = np.percentile(self.dose_opt.array,[99.9])[0].round(decimals=-1)
         clim = [0, max(max_dose_m, max_dose_opt)]   
         fig, ((ax1,ax2,ax3),(ax4,ax5,ax6),(ax7,ax8,ax9)) = plt.subplots(3,3,figsize=(14, 9))
+        axes = [ax1, ax2, ax3, ax4, ax5, ax6, ax7, ax8, ax9]
 
         self.dose_r.plotCB(ax1,clim=clim, title='Red channel dose')
         self.dose_g.plotCB(ax2,clim=clim, title='Green channel dose')
@@ -306,6 +307,9 @@ class Gaf:
         self.dose_opt_RE.plotCB(ax9, clim = [0, np.percentile(self.dose_opt_RE.array, [99.5])[0]], cmap='gray', title='Residuals')
         
         fig.tight_layout()
+        if show: 
+            plt.multi = MultiCursor(None, (axes), color='r', lw=1, horizOn=True)
+            plt.show()
         
     def save_analyzed_image(self, filename, **kwargs):
         """Save the analyzed image to a file.
@@ -317,7 +321,7 @@ class Gaf:
         kwargs
             Keyword arguments are passed to plt.savefig().
         """
-        self.show_results()
+        self.show_results(**kwargs)
         fig = plt.gcf()
         fig.savefig(filename)
         plt.close(fig)
@@ -341,14 +345,13 @@ class Gaf:
             Whether or not to open the PDF file after it is created.
             Default is False.
         """
-        if filename is None:
-            filename = os.path.join(self.path, 'Report.pdf')
+        if filename is None: filename = os.path.join(self.path, 'Report.pdf')
         title='Film-to-Dose Report'
         # canvas = pdf.create_pylinac_page_template(filename, analysis_title=title)
         canvas = pdf.PylinacCanvas(filename, page_title=title, logo=Path(__file__).parent / 'OMG_Logo.png')
         
         data = io.BytesIO()
-        self.save_analyzed_image(data)
+        self.save_analyzed_image(data, show = False)
         canvas.add_image(image_data=data, location=(0.5, 2), dimensions=(20, 20))
         canvas.add_text(text='Film infos:', location=(1, 25.5), font_size=12)
         text = ['Author: {}'.format(self.info['author']),
@@ -373,8 +376,7 @@ class Gaf:
             canvas.add_text(text='Notes:', location=(1, 2.5), font_size=14)
             canvas.add_text(text=self.info['notes'], location=(1, 2), font_size=14)
         canvas.finish()
-        if open_file:
-            webbrowser.open(filename)
+        if open_file: webbrowser.open(filename)
     
     # def apply_factor_from_roi(self, norm_dose = None):
     #     """ Define an ROI on an unexposed film to correct for scanner response. """

--- a/src/omg_dosimetry/tiff2dose.py
+++ b/src/omg_dosimetry/tiff2dose.py
@@ -17,7 +17,8 @@ Features:
     - Publish PDF report
         
 Written by Jean-Francois Cabana, copyright 2018
-Edit par Peter Truong: 2023-10-05
+Modified by Peter Truong (CISSSO)
+Version: 2023-11-30
 """
 
 import os


### PR DESCRIPTION
Hello there. Here at CISSSO, we've been using/updating from a version of OMG Film Dosimetry python modules prior to its introduction here onto Github. Going to try to keep the summarized changes brief and focus on the major updates/feature revisions.
Additional information (i.e., thought process/explanation for re-work) can be found in commit descriptions.  

General formatting:
- New line statements to improve print readability
- Tried to maintain function/script description/commentary

analysis.py:
- norm_film_dose integration: added the possibility to use a separate scan for the normalization film (i.e., 300 MU). If exists, it will be used to acquire the reference normalization factor. Having a separate scan can be useful if multiple patient QA has been scanned during the same day, to which the separate normalization scan (scan image files) can be re-used.  Another use would be if there exists lateral/longitudinal scanner response issues where scanning in the center of the scanner (for both the QA and normalization film) would decrease this response effect.
- Fixed up some issues with closing the self.fig (commonly found in functions depending on an event/action) prior to the call for plt.wait, where there will be a missing fig/plt instance pointing to it. Spyder is able to work around this, but other IDE unfortunately will crash as a consequence. 
  - Updated the plt.wait statement to be 1 second as opposed to 5 second. Quicken the workflow a bit (definitely more convenient when testing code, but also nice to just be generally faster). 
- Vertical line present in profiles created (during show_results) to give a better idea of its relation to the crosshair (profile lines) drawn on the results (film, reference, gamma, RSE plots)
- Inclusion of filename of the film and reference dose in the results figure title per axis
   - Inclusion of the particular gamma analysis criteria in the title of the results figure
- select_markers function has been reworked to simplify view and general usage
   - Limit number of marker selection to 4
   - Fixed a bug where ax.clear() would occur when pressing "hotkeys" for zoom/full-screen (and obviously other tools). This would conflict with the self.film_dose.array manipulations (rotate, flip, etc.). 
      - Removed markers when these manipulations occur as the array/figure has changed
   - Added an option where if no markers are selected, the top, right, bottom, left (center) sides have been selected
      - Not perfect, but at least it serves as an option where markers were forgotten/omitted during the irradiation step. Further registration position tuning can be done to further align.
- set_profiles function has been reworked that now includes clicking in the profile to change the view in the other profile (vertical line: ultimately moving the crosshair as well)
   - Required introducing a self.prof_x, y variable to store the profile position
   - Cleaned up set_profiles function in general to simply be based on the cursor type and a click

calibration.py
- Added default parameter for variable savefile in show_results function call. When working with the calibration python module (command line prompts), not relevant to have to the savefile save/exist when wanting to view the results.

tiff2dose.py
- Updated the clim range for consistency, disturbance, residuals as the previous values did not show much relevant information that could be extracted

OMG_CISSSO_Test.py:
- Included example QA patient tiff2analysis test file to demonstrate how the OMG film dosimetry python module is implemented/utilized at CISSSO.
- Useful implementation would be the selection of the scan, reference dose file path
- Future implementation would be to fully integrate the input for info variable, LUT selection, other tiff2dose parameters perhaps.

Happy reviewing.
Cheers,
Peter

**Edit:** didn't realize that by pushing new commits from my local repository would cause it to be included in the pull request... Whoops. Anyways, a summary (particular changes are described in the commit notes):
Analysis_Pickle is designed to simply load in .pkl files (calibration, tiff2dose, or tiff2analysis/dose2analysis) and simply show the results. It has been mainly been used as a debugging tool (since it will reload the src scripts when loading the pkl object: calibration, tiff2dose, analysis). It can serve as a standalone tool (in the form of a batch file to launch outside of the Spyder environment, but within Windows calling Python itself) to "load" in resultant tiff2analysis/dose2analysis pickled files (if you're including this in your workflow) to simply illustrate the results (yet allowing interactive features such as viewing the dose, gamma, profiles, etc. as opposed to a static result published by the pdf).

**Edit 2:** per request by JF, I have re-converted the profile pixel position back to mm. Updated what happens to xdata when a click on the profile is done to re-convert the mm x_axis back into pixel position. More details can be found in the commit description (2023-12-15).