### PR TITLE
Tiff to dose module

### DIFF
--- a/docs/source/calibration.rst
+++ b/docs/source/calibration.rst
@@ -16,7 +16,7 @@ To run the demo, import the main class and run the demo method:
 .. plot::
     :include-source:
 
-    from omg_dosimetry import LUT
+    from omg_dosimetry.calibration import LUT
 
     LUT.run_demo()
 

--- a/docs/source/calibration.rst
+++ b/docs/source/calibration.rst
@@ -29,7 +29,7 @@ Import :class:`~omg_dosimetry.calibration.LUT` and Path
 
 .. code-block:: python
 
-    from omg_dosimetry import LUT
+    from omg_dosimetry.calibration import LUT
     from pathlib import Path
     import matplotlib.pyplot as plt
 

--- a/docs/source/calibration.rst
+++ b/docs/source/calibration.rst
@@ -35,6 +35,8 @@ Import :class:`~omg_dosimetry.calibration.LUT` and Path
 
 Define the folder containing the scanned tiff images, and the nominal doses [cGy] imparted to the films
 
+.. note:: Only 16-bit/channel RGB tiff images are supported.
+
 .. code-block:: python
 
     my_path = Path(r"C:/my/folder")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,6 +22,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode',
     'sphinx_copybutton',
     "matplotlib.sphinxext.plot_directive",
 ]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,7 @@ author = 'Jean-François Cabana, Luis Alfonso Olivares Jiménez and Peter Truong
 # The short X.Y version.
 version = "1.6"
 # The full version, including alpha/beta/rc tags.
-release = "1.6.1"
+release = "1.6.2"
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,12 +8,12 @@
 
 project = 'OMG dosimetry'
 copyright = '2023, Jean-François Cabana and Luis Alfonso Olivares Jiménez'
-author = 'Jean-François Cabana and Luis Alfonso Olivares Jiménez'
+author = 'Jean-François Cabana, Luis Alfonso Olivares Jiménez and Peter Truong'
 
 # The short X.Y version.
-version = "1.5"
+version = "1.6"
 # The full version, including alpha/beta/rc tags.
-release = "1.5.5"
+release = "1.6.0"
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 

--- a/docs/source/tiff2dose.rst
+++ b/docs/source/tiff2dose.rst
@@ -23,10 +23,8 @@ To run the demo, import the main class and run the demo method:
 API Documentation
 =================
 
-Main classes
-------------
-
-These are the classes a typical user may interface with.
+Main class
+----------
 
 .. autoclass:: omg_dosimetry.tiff2dose.Gaf
     :members:

--- a/docs/source/tiff2dose.rst
+++ b/docs/source/tiff2dose.rst
@@ -8,6 +8,17 @@ Overview
 .. automodule:: omg_dosimetry.tiff2dose
     :no-members:
 
+Running the Demo
+----------------
+
+To run the demo, import the main class and run the demo method:
+
+.. plot::
+    :include-source:
+
+    from omg_dosimetry.tiff2dose import Gaf
+
+    Gaf.run_demo()
 
 API Documentation
 =================

--- a/docs/source/tiff2dose.rst
+++ b/docs/source/tiff2dose.rst
@@ -20,6 +20,64 @@ To run the demo, import the main class and run the demo method:
 
     Gaf.run_demo()
 
+Usage
+-----
+
+Import :class:`~omg_dosimetry.tiff2dose.Gaf` and Path:
+
+.. code-block:: python
+
+    from omg_dosimetry.tiff2dose import Gaf
+    from pathlib import Path
+    import matplotlib.pyplot as plt
+
+Define the folder containing the scanned tiff images, and path to LUT file
+
+.. code-block:: python
+
+    my_path = Path(r"C:/my/folder/QA")
+    path_to_lut = Path(r"/my/folder/lut_calib.pkl")
+
+If you don't have an image you can load the demo image and run LUT.run_demo():
+
+.. code-block:: python
+
+    from omg_dosimetry import tiff2dose
+    my_path = tiff2dose.from_demo_image()
+
+.. plot::
+
+    from omg_dosimetry.i_o import retrieve_demo_file
+    from omg_dosimetry.imageRGB import load
+    img_path = retrieve_demo_file("A1A_Multi_6cm_001.tif")
+    img = load(img_path)
+    img.plot(show=True)
+
+Define the function type used for fitting calibration curve. 'rational' (recommended) or 'spline'
+
+.. code-block:: python
+
+    fit_type = 'rational'
+
+Maximum value [cGy] to limit dose. Useful to avoid very high doses obtained
+due to markings on the film.
+
+.. code-block:: python
+
+    clip = 500
+
+Produce the Gaf object
+
+.. code-block:: python
+
+    gaf = Gaf(my_path, lut_file=path_to_lut, fit_type=fit_type, clip=clip)
+
+Display a figure with the different converted dose maps and metrics.
+
+.. code-block:: python
+
+    gaf.show_results(show=True)
+
 API Documentation
 =================
 

--- a/docs/source/tiff2dose.rst
+++ b/docs/source/tiff2dose.rst
@@ -29,21 +29,22 @@ Import :class:`~omg_dosimetry.tiff2dose.Gaf` and Path:
 
     from omg_dosimetry.tiff2dose import Gaf
     from pathlib import Path
-    import matplotlib.pyplot as plt
 
 Define the folder containing the scanned tiff images, and path to LUT file
 
 .. code-block:: python
 
-    my_path = Path(r"C:/my/folder/QA")
-    path_to_lut = Path(r"/my/folder/lut_calib.pkl")
+    path_to_tif_folder = Path(r"C:/my/folder/tifQA")
+    path_to_lut_file = Path(r"/my/folder/lut_calib.pkl")
 
-If you don't have an image you can load the demo image and run LUT.run_demo():
+If you don't have an image you can load the demo image and lut files:
 
 .. code-block:: python
 
     from omg_dosimetry import tiff2dose
-    my_path = tiff2dose.from_demo_image()
+
+    path_to_tif_folder = tiff2dose.from_demo_image()
+    path_to_lut_file = tiff2dose.from_demo_lut()
 
 .. plot::
 
@@ -70,19 +71,19 @@ Produce the Gaf object
 
 .. code-block:: python
 
-    gaf = Gaf(my_path, lut_file=path_to_lut, fit_type=fit_type, clip=clip)
+    gaf = Gaf(path_to_tif_folder, lut_file=path_to_lut_file, fit_type=fit_type, clip=clip)
 
 Display a figure with the different converted dose maps and metrics.
 
 .. code-block:: python
 
-    gaf.show_results(show=True)
+    gaf.show_results()
 
 API Documentation
-=================
+-----------------
 
 Main class
-----------
+^^^^^^^^^^
 
 .. autoclass:: omg_dosimetry.tiff2dose.Gaf
     :members:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "omg_dosimetry"
 
-version = "1.6.1"
+version = "1.6.2"
 
 authors = [
   { name="JF Cabana", email="jean-francois.cabana.cisssca@ssss.gouv.qc.ca" },

--- a/src/omg_dosimetry/__init__.py
+++ b/src/omg_dosimetry/__init__.py
@@ -1,1 +1,2 @@
 from .calibration import LUT
+from .tiff2dose import Gaf

--- a/src/omg_dosimetry/calibration.py
+++ b/src/omg_dosimetry/calibration.py
@@ -43,10 +43,8 @@ from scipy.interpolate import UnivariateSpline
 from pathlib import Path
 import webbrowser
 from .imageRGB import load, load_folder, stack_images
-#from imageRGB import load, load_folder, stack_images
 import bz2
 from .i_o import retrieve_demo_file
-#from i_o import retrieve_demo_file
 
 class LUT:
     """

--- a/src/omg_dosimetry/calibration.py
+++ b/src/omg_dosimetry/calibration.py
@@ -42,9 +42,11 @@ from random import randint
 from scipy.interpolate import UnivariateSpline
 from pathlib import Path
 import webbrowser
-from .imageRGB import load, load_folder, stack_images
+#from .imageRGB import load, load_folder, stack_images
+from imageRGB import load, load_folder, stack_images
 import bz2
-from .i_o import retrieve_demo_file
+#from .i_o import retrieve_demo_file
+from i_o import retrieve_demo_file
 
 class LUT:
     """
@@ -236,7 +238,7 @@ class LUT:
         retrieve_demo_file("C14_calib-18h-1_001.tif")
         retrieve_demo_file("C14_calib-18h-2_001.tif")
 
-        demo_path = Path(__file__).parent / "demo_files"       # Folder containing scanned images
+        demo_path = Path(__file__).parent / "demo_files" / "calibration"      # Folder containing scanned images
         outname = 'Demo_calib'                                 ## Name of the calibration file to produce
 
         #%% Set calibration parameters

--- a/src/omg_dosimetry/calibration.py
+++ b/src/omg_dosimetry/calibration.py
@@ -275,7 +275,8 @@ class LUT:
         #lut.publish_pdf(filename=os.path.join(demo_path, outname +'_report.pdf'), open_file=True)            # Generate a PDF report
         save_lut(lut, filename=os.path.join(demo_path.parent, outname + '.pkl'), use_compression=True)  # Save the LUT file. use_compression allows a reduction  
                                                                                                         # in file size by a factor of ~10, but slows down the operation.
-        lut.show_results(io.BytesIO(), show = show)
+        if show:
+            lut.show_results(io.BytesIO())
 
     def load_images(self,path,filt):
         """ Load all images in a folder. Average multiple copies of same image

--- a/src/omg_dosimetry/calibration.py
+++ b/src/omg_dosimetry/calibration.py
@@ -215,13 +215,15 @@ class LUT:
             self.select_film()
 
     @staticmethod
-    def run_demo(film_detect = True) -> None:
+    def run_demo(film_detect = True, show = True) -> None:
         """Run the LUT demo by loading the demo images and print results.
         
         Parameters
         ----------
         film_detect : bool
             True to attempt automatic film detection, or False to make a manual selection.
+        show : bools
+            Display a summary of the results.
         """
 
         info = dict(author = 'Demo Physicist',
@@ -275,7 +277,7 @@ class LUT:
         #lut.publish_pdf(filename=os.path.join(demo_path, outname +'_report.pdf'), open_file=True)            # Generate a PDF report
         save_lut(lut, filename=os.path.join(demo_path.parent, outname + '.pkl'), use_compression=True)  # Save the LUT file. use_compression allows a reduction  
                                                                                                         # in file size by a factor of ~10, but slows down the operation.
-        lut.show_results(io.BytesIO(), show = True)
+        lut.show_results(io.BytesIO(), show = show)
 
     def load_images(self,path,filt):
         """ Load all images in a folder. Average multiple copies of same image

--- a/src/omg_dosimetry/calibration.py
+++ b/src/omg_dosimetry/calibration.py
@@ -238,7 +238,8 @@ class LUT:
         retrieve_demo_file("C14_calib-18h-1_001.tif")
         retrieve_demo_file("C14_calib-18h-2_001.tif")
 
-        demo_path = Path(__file__).parent / "demo_files" / "calibration"      # Folder containing scanned images
+        # Folder containing scanned images
+        demo_path = Path(__file__).parent / "demo_files" / "calibration" / "scan"
         outname = 'Demo_calib'                                 ## Name of the calibration file to produce
 
         #%% Set calibration parameters
@@ -272,7 +273,7 @@ class LUT:
         #LUT.plot_roi()  # To display films and ROIs used for calibration
         #LUT.plot_fit()  # To display a plot of the calibration curve and the fitted algebraic function
         #lut.publish_pdf(filename=os.path.join(demo_path, outname +'_report.pdf'), open_file=True)            # Generate a PDF report
-        save_lut(lut, filename=os.path.join(demo_path, outname + '.pkl'), use_compression=True)  # Save the LUT file. use_compression allows a reduction  
+        save_lut(lut, filename=os.path.join(demo_path.parent, outname + '.pkl'), use_compression=True)  # Save the LUT file. use_compression allows a reduction  
                                                                                                         # in file size by a factor of ~10, but slows down the operation.
         lut.show_results(io.BytesIO(), show = True)
 

--- a/src/omg_dosimetry/calibration.py
+++ b/src/omg_dosimetry/calibration.py
@@ -42,11 +42,11 @@ from random import randint
 from scipy.interpolate import UnivariateSpline
 from pathlib import Path
 import webbrowser
-#from .imageRGB import load, load_folder, stack_images
-from imageRGB import load, load_folder, stack_images
+from .imageRGB import load, load_folder, stack_images
+#from imageRGB import load, load_folder, stack_images
 import bz2
-#from .i_o import retrieve_demo_file
-from i_o import retrieve_demo_file
+from .i_o import retrieve_demo_file
+#from i_o import retrieve_demo_file
 
 class LUT:
     """

--- a/src/omg_dosimetry/i_o.py
+++ b/src/omg_dosimetry/i_o.py
@@ -20,7 +20,8 @@ def retrieve_demo_file(name: str, force: bool = False) -> Path:
     urls = {
         "C14_calib-18h-1_001.tif": r"https://raw.githubusercontent.com/jfcabana/omg_dosimetry/OMG_master/scripts/demo/files/calibration/scan/",
         "C14_calib-18h-2_001.tif": r"https://raw.githubusercontent.com/jfcabana/omg_dosimetry/OMG_master/scripts/demo/files/calibration/scan/",
-        "BeamProfile.txt": r"https://raw.githubusercontent.com/jfcabana/omg_dosimetry/OMG_master/scripts/demo/files/calibration/"
+        "BeamProfile.txt": r"https://raw.githubusercontent.com/jfcabana/omg_dosimetry/OMG_master/scripts/demo/files/calibration/",
+        "A1A_Multi_6cm_001.tif": r"https://raw.githubusercontent.com/jfcabana/omg_dosimetry/OMG_master/scripts/demo/files/tiff2dose/scan/"
         }
     
     url = urls[name] + name

--- a/src/omg_dosimetry/i_o.py
+++ b/src/omg_dosimetry/i_o.py
@@ -21,15 +21,46 @@ def retrieve_demo_file(name: str, force: bool = False) -> Path:
         "C14_calib-18h-1_001.tif": r"https://raw.githubusercontent.com/jfcabana/omg_dosimetry/OMG_master/scripts/demo/files/calibration/scan/",
         "C14_calib-18h-2_001.tif": r"https://raw.githubusercontent.com/jfcabana/omg_dosimetry/OMG_master/scripts/demo/files/calibration/scan/",
         "BeamProfile.txt": r"https://raw.githubusercontent.com/jfcabana/omg_dosimetry/OMG_master/scripts/demo/files/calibration/",
-        "A1A_Multi_6cm_001.tif": r"https://raw.githubusercontent.com/jfcabana/omg_dosimetry/OMG_master/scripts/demo/files/tiff2dose/scan/"
+        "A1A_Multi_6cm_001.tif": r"https://raw.githubusercontent.com/jfcabana/omg_dosimetry/OMG_master/scripts/demo/files/tiff2dose/scan/",
+        "RD1.2.752.243.1.1.20230116114244452.3800.11382.3.313.2.dcm": r"https://raw.githubusercontent.com/jfcabana/omg_dosimetry/OMG_master/scripts/demo/files/analysis/DoseRS/"
         }
-    
+
     url = urls[name] + name
-    demo_path = Path(__file__).parent / "demo_files" / name
+    #demo_path = Path(__file__).parent / "demo_files" / name
     
-    demo_dir = demo_path.parent
-    if not demo_dir.exists():
-        os.makedirs(demo_dir)
-    if force or not demo_path.exists():
-        get_url(url, destination=demo_path)
+    
+    # Root directory and path to demos
+    #demo_dir = demo_path.parent
+    root_demo_path = Path(__file__).parent / "demo_files"
+    if not root_demo_path.exists():
+        os.makedirs(root_demo_path)
+    calib_demo_path = root_demo_path / "calibration"
+    if not calib_demo_path.exists():
+        os.makedirs(calib_demo_path)
+    tiff2dose_demo_path = root_demo_path / "tiff2dose"
+    if not tiff2dose_demo_path.exists():
+        os.makedirs(tiff2dose_demo_path)
+    analysis_demo_path = root_demo_path / "analysis"
+    if not analysis_demo_path.exists():
+        os.makedirs(analysis_demo_path)
+
+    #if not demo_dir.exists():
+    #    os.makedirs(demo_dir)
+    if name == "C14_calib-18h-1_001.tif" or name == "C14_calib-18h-2_001.tif":
+        demo_path = calib_demo_path / name
+        if force or not demo_path.exists():
+            get_url(url, destination=demo_path)
+    elif name == "BeamProfile.txt":
+        demo_path = calib_demo_path / name
+        if force or not demo_path.exists():
+            get_url(url, destination=demo_path)
+    elif name == "A1A_Multi_6cm_001.tif":
+        demo_path = tiff2dose_demo_path / name
+        if force or not demo_path.exists():
+            get_url(url, destination=demo_path)
+    elif name == "RD1.2.752.243.1.1.20230116114244452.3800.11382.3.313.2.dcm":
+        demo_path = analysis_demo_path / name
+        if force or not demo_path.exists():
+            get_url(url, destination=demo_path)
+
     return demo_path

--- a/src/omg_dosimetry/i_o.py
+++ b/src/omg_dosimetry/i_o.py
@@ -34,13 +34,13 @@ def retrieve_demo_file(name: str, force: bool = False) -> Path:
     root_demo_path = Path(__file__).parent / "demo_files"
     if not root_demo_path.exists():
         os.makedirs(root_demo_path)
-    calib_demo_path = root_demo_path / "calibration"
+    calib_demo_path = root_demo_path / "calibration" / "scan"
     if not calib_demo_path.exists():
         os.makedirs(calib_demo_path)
-    tiff2dose_demo_path = root_demo_path / "tiff2dose"
+    tiff2dose_demo_path = root_demo_path / "tiff2dose" / "scan"
     if not tiff2dose_demo_path.exists():
         os.makedirs(tiff2dose_demo_path)
-    analysis_demo_path = root_demo_path / "analysis"
+    analysis_demo_path = root_demo_path / "analysis" / "scan"
     if not analysis_demo_path.exists():
         os.makedirs(analysis_demo_path)
 

--- a/src/omg_dosimetry/tiff2dose.py
+++ b/src/omg_dosimetry/tiff2dose.py
@@ -31,13 +31,13 @@ import io
 from matplotlib.widgets  import RectangleSelector, MultiCursor
 import webbrowser
 from pathlib import Path
-#from .imageRGB import load, load_multiples
-#from .calibration import load_lut
-#from .i_o import retrieve_demo_file
+from .imageRGB import load, load_multiples
+from .calibration import load_lut, LUT
+from .i_o import retrieve_demo_file
 
-from imageRGB import load, load_multiples
-from calibration import load_lut, LUT
-from i_o import retrieve_demo_file
+#from imageRGB import load, load_multiples
+#from calibration import load_lut, LUT
+#from i_o import retrieve_demo_file
 
 class Gaf:
     """Base class for gafchromic films converted to dose.
@@ -150,7 +150,7 @@ class Gaf:
             self.dose_consistency.crop_edges(threshold=crop_edges)
 
     @staticmethod
-    def run_demo(show=True) -> None:
+    def run_demo() -> None:
         """Run the Gaf demo by loading the demo image and print results."""
 
         # Define general information
@@ -189,16 +189,16 @@ class Gaf:
         gaf1 = Gaf(path = demo_path, lut_file=lut_file, fit_type=fit_type, info=info, clip = clip)
 
         # Save dose and PDF report
-        filename_tif = demo_path.parent / str(outname + ".tif")
+        #filename_tif = demo_path.parent / str(outname + ".tif")
 
         # We save the optimized dose (dose_opt). Other options include individual channels 
         # (dose_r, dose_g, dose_b) and individual channels doses average (dose_ave).
-        gaf1.dose_opt.save(filename_tif)
+        #gaf1.dose_opt.save(filename_tif)
 
-        gaf1.show_results(io.BytesIO(), show=show)
+        #filename_pdf = demo_path / str(outname + ".pdf")
+        #gaf1.publish_pdf(str(filename_pdf), open_file=True)
 
-        filename_pdf = demo_path / str(outname + ".pdf")
-        gaf1.publish_pdf(str(filename_pdf), open_file=True)
+        gaf1.show_results(io.BytesIO(), show=True)
 
     def load_files(self, path):
         """ Load image files found in path. 
@@ -341,7 +341,7 @@ class Gaf:
         self.dose_rg = load((dose_r+dose_g)/2., dpi=self.img.dpi)  
         self.dose_consistency = load(((dose_r-dose_g)**2 + (dose_r-dose_b)**2 + (dose_b-dose_g)**2)**0.5, dpi=self.img.dpi)  
         
-    def show_results(self, show = True):
+    def show_results(self, savefile = None, show = True):
         """ Display a figure with the different converted dose maps and metrics.
         """
 
@@ -363,6 +363,8 @@ class Gaf:
         self.dose_opt_RE.plotCB(ax9, clim = [0, np.percentile(self.dose_opt_RE.array, [99.5])[0]], cmap='gray', title='Residuals')
         
         fig.tight_layout()
+        
+        if savefile: plt.savefig(savefile)
         if show: 
             plt.multi = MultiCursor(None, (axes), color='r', lw=1, horizOn=True)
             plt.show()

--- a/src/omg_dosimetry/tiff2dose.py
+++ b/src/omg_dosimetry/tiff2dose.py
@@ -2,9 +2,10 @@
 """
 OMG Dosimetry tiff2dose module.
 
-The film-to-dose module performs optimized multichannel conversion from scanned gafchromic films to absolute dose.
-It uses the optimized multichannel method from Mayer et al (https://doi.org/10.1118/1.3694100)
-and calibration curves obtained with the calibration module.
+The film-to-dose module performs optimized multichannel conversion from scanned
+gafchromic films to absolute dose. It uses the optimized multichannel method from
+Mayer et al (https://doi.org/10.1118/1.3694100) and calibration curves obtained
+with the calibration module.
 
 Features:
     - Multiple scans of same film are loaded and averaged automatically
@@ -15,10 +16,10 @@ Features:
     - Output individual channels dose (R/G/B), as well as optimized dose, mean channel dose and average dose
     - Output metrics for evaluation of dose conversion quality: disturbance map, residual error, consistency map
     - Publish PDF report
-        
+
 Written by Jean-Francois Cabana, copyright 2018
 Modified by Peter Truong (CISSSO) and Luis Alfonso Olivares Jimenez
-Version: 2023-12-26
+Version: 2024-01-03
 """
 
 import os
@@ -28,7 +29,7 @@ import matplotlib.pyplot as plt
 import pickle
 from pylinac.core import pdf
 import io
-from matplotlib.widgets  import RectangleSelector, MultiCursor
+from matplotlib.widgets import RectangleSelector, MultiCursor
 import webbrowser
 from pathlib import Path
 from .imageRGB import load, load_multiples
@@ -37,22 +38,10 @@ from .i_o import retrieve_demo_file
 
 
 class Gaf:
-    """Base class for gafchromic films converted to dose.
+    """
+    Base class for gafchromic films converted to dose.
 
-    Usage : gaf = tiff2dose.Gaf(path='path/to/scanned/tiff/images', lut_file=l'path/to/calibration/file')
-
-    gaf.dose_r:             ArrayImage object of dose from red channnel
-    gaf.dose_g:             ArrayImage object of dose from green channnel
-    gaf.dose_b:             ArrayImage object of dose from blue channnel
-    gaf.dose_m:             ArrayImage object of dose from mean channnel (dose_m = dose_((r+g+b/3)))    
-    gaf.dose_ave:           ArrayImage object of averaged dose from channels R+G+B ((dose_ave = dose_r + dose_g + dose_b) / 3)
-    gaf.dose_rg:            ArrayImage object of averaged dose from channels R+G ((dose_ave = dose_r + dose_g) / 2)
-    gaf.dose_opt:           ArrayImage object of optimized dose (eq. 6 in Mayer et al)
-    gaf.dose_opt_delta:     ArrayImage object of disturbance map (eq. 7 in Mayer et al)
-    gaf.dose_opt_RE:        ArrayImage object of residual error (eq. 2 in Mayer et al)
-    gaf.dose_consistency:   ArrayImage object of disagreement between individual channels (RMSE of (dose_r-dose_g) + (dose_r-dose_b) + (dose_b-dose_g))
-
-    Attributes
+    Parameters
     ----------
 
     path : str
@@ -75,7 +64,8 @@ class Gaf:
     fit_type : 'rational' or 'spline'
         Function type used for fitting calibration curve.
         Default is 'rational'.
-        If fit_type = "spline", the fitted function is UnivariateSpline from scipy.interpolate.
+        If fit_type = "spline", the fitted function is UnivariateSpline from
+        scipy.interpolate.
         'k', 'ext', and 's' are parameters to pass to this function.
 
     k : int, optional
@@ -91,7 +81,8 @@ class Gaf:
         If 0, spline will interpolate through all data points. Default is None.
 
     ext : int or str, optional
-        Controls the extrapolation mode for elements not in the interval defined by the knot sequence.
+        Controls the extrapolation mode for elements not in the interval defined by
+        the knot sequence.
         * if ext=0 or 'extrapolate', return the extrapolated value.
         * if ext=1 or 'zeros', return 0
         * if ext=2 or 'raise', raise a ValueError
@@ -100,13 +91,14 @@ class Gaf:
 
     info : dictionary, optional
         Used to store information that will be shown on the PDF report.
-        key:value pairs must include "author", "unit", "film_lot", "scanner_id", date_exposed", "date_scanned", "wait_time", "notes"
+        key:value pairs must include "author", "unit", "film_lot", "scanner_id",
+        date_exposed", "date_scanned", "wait_time", "notes"
         Default is None.
 
     crop_edges : int, optional
         If not 0, dose arrays will be cropped to remove empty areas around the film.
-        The actual value determines the threshold used for detecting what is considered non-film area.
-        Default is 0.
+        The actual value determines the threshold used for detecting what is
+        considered non-film area. Default is 0.
 
     clip : float, optional
         Maximum value [cGy] to limit dose.
@@ -116,24 +108,81 @@ class Gaf:
     rot90 : int, optional
         Number of 90 degrees rotations to apply to the image.
         Default is 0.
+
+    Attributes
+    ----------
+
+    gaf.dose_r:             ArrayImage object of dose from red channnel
+    gaf.dose_g:             ArrayImage object of dose from green channnel
+    gaf.dose_b:             ArrayImage object of dose from blue channnel
+    gaf.dose_m:             ArrayImage object of dose from mean channnel (dose_m = dose_((r+g+b/3)))
+    gaf.dose_ave:           ArrayImage object of averaged dose from channels R+G+B ((dose_ave = dose_r + dose_g + dose_b) / 3)
+    gaf.dose_rg:            ArrayImage object of averaged dose from channels R+G ((dose_ave = dose_r + dose_g) / 2)
+    gaf.dose_opt:           ArrayImage object of optimized dose (eq. 6 in Mayer et al)
+    gaf.dose_opt_delta:     ArrayImage object of disturbance map (eq. 7 in Mayer et al)
+    gaf.dose_opt_RE:        ArrayImage object of residual error (eq. 2 in Mayer et al)
+    gaf.dose_consistency:   ArrayImage object of disagreement between individual channels (RMSE of (dose_r-dose_g) + (dose_r-dose_b) + (dose_b-dose_g))
+
+    Example
+    -------
+
+    .. code-block:: python
+
+        gaf = tiff2dose.Gaf(
+            path='path/to/scanned/tiff/images',
+            lut_file='path/to/calibration/file'
+        )
+
     """
 
-    def __init__(self, path='', lut_file='', img_filt=0, lut_filt=35, fit_type='rational', k=3, ext=3, s=None, info=None, crop_edges=0, clip=None, rot90=0):   
-        
+    def __init__(
+        self,
+        path='',
+        lut_file='',
+        img_filt=0,
+        lut_filt=35,
+        fit_type='rational',
+        k=3,
+        ext=3,
+        s=None,
+        info=None,
+        crop_edges=0,
+        clip=None,
+        rot90=0
+    ):
+
         if info is None:
-            info = dict(author = '', unit = '', film_lot = '', scanner_id = '', date_exposed = '', date_scanned = '', wait_time = '', notes = '')
+            info = dict(
+                author='',
+                unit='',
+                film_lot='',
+                scanner_id='',
+                date_exposed='',
+                date_scanned='',
+                wait_time='',
+                notes=''
+            )
         self.path = path
         self.lut_file = lut_file
         self.img_filt = img_filt
         self.lut_filt = lut_filt
         self.fit_type = fit_type
         self.info = info
-        self.lut = load_lut(lut_file)       
+        self.lut = load_lut(lut_file)
         self.load_files(path)
         self.clip = clip
-        if rot90: self.img.array = np.rot90(self.img.array, k=rot90)   
-        self.convert2dose(img_filt=img_filt, lut_filt=lut_filt, fit_type=fit_type, k=k, ext=ext, s=s)
-        
+        if rot90:
+            self.img.array = np.rot90(self.img.array, k=rot90)
+
+        self.convert2dose(
+            img_filt=img_filt,
+            lut_filt=lut_filt,
+            fit_type=fit_type,
+            k=k,
+            ext=ext,
+            s=s
+        )
+
         if crop_edges:
             self.dose_ave.crop_edges(threshold=crop_edges)
             self.dose_m.crop_edges(threshold=crop_edges)
@@ -151,24 +200,25 @@ class Gaf:
         """Run the Gaf demo by loading the demo image and print results."""
 
         # Define general information
-        info = dict(author = 'Demo Physicist',
-            unit = 'Demo Linac',
-            film_lot = 'XD_1',
-            scanner_id = 'Epson 72000XL',
-            date_exposed = '2023-01-24 16h',
-            date_scanned = '2023-01-25 16h',
-            wait_time = '24 hours',
-            notes = 'Transmission mode, @300ppp and 16 bits/channel'
-           )
+        info = dict(
+            author='Demo Physicist',
+            unit='Demo Linac',
+            film_lot='XD_1',
+            scanner_id='Epson 72000XL',
+            date_exposed='2023-01-24 16h',
+            date_scanned='2023-01-25 16h',
+            wait_time='24 hours',
+            notes='Transmission mode, @300ppp and 16 bits/channel'
+        )
 
         # Download demo tif files and save it on demo_files folder.
         retrieve_demo_file("A1A_Multi_6cm_001.tif")
 
         # Folder containing scanned image
         demo_path = Path(__file__).parent / "demo_files" / "tiff2dose" / "scan"
-        
+
         # Name of the output file to produce
-        outname = "Demo_dose"
+        # outname = "Demo_dose"
 
         # Path to LUT film to use
         lut_file = Path(__file__).parent / "demo_files" / "calibration" / "Demo_calib.pkl"
@@ -176,32 +226,43 @@ class Gaf:
             print("Running LUT.run_demo()...")
             LUT.run_demo(show=False)
 
-        # Function type used for fitting calibration curve. 'rational' (recommended) or 'spline'
+        # Function type used for fitting calibration curve. 'rational' (recommended)
+        # or 'spline'
         fit_type = 'rational'
 
-        # Maximum value [cGy] to limit dose. Useful to avoid very high doses obtained due to markings on the film.
+        # Maximum value [cGy] to limit dose. Useful to avoid very high doses obtained
+        # due to markings on the film.
         clip = 500
 
         # Perform dose conversion
-        gaf1 = Gaf(path = demo_path, lut_file=lut_file, fit_type=fit_type, info=info, clip = clip)
+        gaf1 = Gaf(
+            path=demo_path,
+            lut_file=lut_file,
+            fit_type=fit_type,
+            info=info,
+            clip=clip
+        )
 
         # Save dose and PDF report
-        #filename_tif = demo_path.parent / str(outname + ".tif")
+        # filename_tif = demo_path.parent / str(outname + ".tif")
 
-        # We save the optimized dose (dose_opt). Other options include individual channels 
-        # (dose_r, dose_g, dose_b) and individual channels doses average (dose_ave).
-        #gaf1.dose_opt.save(filename_tif)
+        # We save the optimized dose (dose_opt). Other options include
+        # individual channels (dose_r, dose_g, dose_b) and individual
+        # channels doses average (dose_ave). gaf1.dose_opt.save(filename_tif)
 
-        #filename_pdf = demo_path / str(outname + ".pdf")
-        #gaf1.publish_pdf(str(filename_pdf), open_file=True)
+        # filename_pdf = demo_path / str(outname + ".pdf")
+        # gaf1.publish_pdf(str(filename_pdf), open_file=True)
 
         gaf1.show_results(io.BytesIO(), show=True)
 
     def load_files(self, path):
-        """ Load image files found in path. 
-            If path is a directory, it is assumed to contains multiples scans of a single film.
-            If a directory contains scans of multiple films, then path should be a full path to a single image.
-            Files sharing the same filename but ending with _00x in this directory are assumed to be scans of the same film and will be averaged together to increse SNR.
+        """
+        Load image files found in path.
+        If path is a directory, it is assumed to contains multiples scans of a
+        single film. If a directory contains scans of multiple films, then path
+        should be a full path to a single image. Files sharing the same filename
+        but ending with _00x in this directory are assumed to be scans of the
+        same film and will be averaged together to increse SNR.
         """
 
         if os.path.isdir(path):
@@ -210,27 +271,40 @@ class Gaf:
             filename = os.path.basename(files[0])
             if filename == 'Thumbs.db':
                 filename = os.path.basename(files[1])
+
         else:
             folder = os.path.dirname(path)
             filename = os.path.basename(path)
             files = os.listdir(folder)
+
         self.filename = filename
         file_list = []
-        filebase, fileext = os.path.splitext(filename)   
-        if filebase[-3:-1] == '00':
+        filebase, fileext = os.path.splitext(filename)
+        if filebase[-3: -1] == '00':
             for file in files:
                 name, fileext = os.path.splitext(file)
-                if name.lower()[0:-4] == filebase.lower()[0:-4]:
-                    file_list.append(os.path.join(folder,name + fileext))
-                    
-        # If path is a list, we assume they are multiple copies of the same film
-        if len(file_list) > 0: self.img = load_multiples(file_list)     
-        else: self.img = load(path)
+                if name.lower()[0: -4] == filebase.lower()[0: -4]:
+                    file_list.append(os.path.join(folder, name + fileext))
 
-    def convert2dose(self, img_filt=0, lut_filt=35, fit_type='rational', k=3, ext=3, s=0):        
-        """ Performs the conversion of scanned image to dose [cGy].
+        # If path is a list, we assume they are multiple copies of the same film
+        if len(file_list) > 0:
+            self.img = load_multiples(file_list)
+        else:
+            self.img = load(path)
+
+    def convert2dose(
+        self,
+        img_filt=0,
+        lut_filt=35,
+        fit_type='rational',
+        k=3,
+        ext=3,
+        s=0
+    ):
         """
-        
+        Performs the conversion of scanned image to dose [cGy].
+        """
+
         img = self.img
         lut = self.lut
         ysize = img.shape[0]
@@ -238,22 +312,28 @@ class Gaf:
 
         # Check that image and LUT sizes match (if lateral correction is used)
         if lut.lateral_correction:
-            if ysize != lut.npixel:
-                raise ValueError("Image dimension does not match LUT resolution!")
-        
+            raise ValueError("Image dimension does not match LUT resolution!")
+
         # Apply median filter on all image channels if needed
         if img_filt:
-            for i in range (0,3):
-                img.array[:,:,i] = medfilt(img.array[:,:,i],  kernel_size=(img_filt,img_filt))
-        
+            for i in range(0, 3):
+                img.array[:, :, i] = medfilt(
+                    img.array[:, :, i],
+                    kernel_size=(img_filt, img_filt)
+                )
+
         # Apply median filter on LUT if needed
         if lut_filt:
             if lut.lateral_correction:
-                for i in range (0,len(lut.doses)):  #loop over all doses
-                    for j in range (2,6):           #loop over all channels (mean,R,G,B)
-                        lut.lut[j,i,:] = medfilt(lut.lut[j,i,:], kernel_size=(lut_filt))
-            else: pass
-        
+                for i in range(0, len(lut.doses)):  # loop over all doses
+                    for j in range(2, 6):  # loop over all channels (mean, R, G, B)
+                        lut.lut[j, i, :] = medfilt(
+                            lut.lut[j, i, :],
+                            kernel_size=(lut_filt)
+                        )
+            else:
+                pass
+
         # Initialize arrays
         dose_m = np.zeros((ysize, xsize))
         dose_r = np.zeros((ysize, xsize))
@@ -263,62 +343,67 @@ class Gaf:
         dose_opt = np.zeros((ysize, xsize))
         delta = np.zeros((ysize, xsize))
         RE = np.zeros((ysize, xsize))
-    
+
         # Convert image to dose one line at a time
-        for i in range(0,ysize):
-            row = img.array[i,:,:]          
+        for i in range(0, ysize):
+            row = img.array[i, :, :]
             if lut.lateral_correction:
-                p_lut = lut.lut[:,:,i]
-                xdata = p_lut[:,:]
-                ydata = p_lut[1,:]
+                p_lut = lut.lut[:, :, i]
+                xdata = p_lut[:, :]
+                ydata = p_lut[1, :]
             else:
-                p_lut = lut.lut[:,:]
+                p_lut = lut.lut[:, :]
                 xdata = p_lut[:]
                 ydata = p_lut[1]
-                
+
             if fit_type == 'rational':
-                Dm, Am = lut.get_dose_and_derivative_from_fit(xdata[2,:], ydata, np.mean(row, axis=-1))
-                Dr, Ar = lut.get_dose_and_derivative_from_fit(xdata[3,:], ydata, row[:,0])
-                Dg, Ag = lut.get_dose_and_derivative_from_fit(xdata[4,:], ydata, row[:,1])
-                Db, Ab = lut.get_dose_and_derivative_from_fit(xdata[5,:], ydata, row[:,2])               
+                Dm, Am = lut.get_dose_and_derivative_from_fit(
+                    xdata[2, :], ydata,
+                    np.mean(row, axis=-1)
+                )
+                Dr, Ar = lut.get_dose_and_derivative_from_fit(xdata[3, :], ydata, row[:, 0])
+                Dg, Ag = lut.get_dose_and_derivative_from_fit(xdata[4, :], ydata, row[:, 1])
+                Db, Ab = lut.get_dose_and_derivative_from_fit(xdata[5, :], ydata, row[:, 2])
             elif fit_type == 'spline':
-                Dm, Am = lut.get_dose_and_derivative_from_spline(xdata[2,:], ydata, np.mean(row, axis=-1), k=k, ext=ext, s=s)
-                Dr, Ar = lut.get_dose_and_derivative_from_spline(xdata[3,:], ydata, row[:,0], k=k, ext=ext, s=s)
-                Dg, Ag = lut.get_dose_and_derivative_from_spline(xdata[4,:], ydata, row[:,1], k=k, ext=ext, s=s)
-                Db, Ab = lut.get_dose_and_derivative_from_spline(xdata[5,:], ydata, row[:,2], k=k, ext=ext, s=s)
-            
+                Dm, Am = lut.get_dose_and_derivative_from_spline(xdata[2, :], ydata, np.mean(row, axis=-1), k=k, ext=ext, s=s)
+                Dr, Ar = lut.get_dose_and_derivative_from_spline(xdata[3, :], ydata, row[:, 0], k=k, ext=ext, s=s)
+                Dg, Ag = lut.get_dose_and_derivative_from_spline(xdata[4, :], ydata, row[:, 1], k=k, ext=ext, s=s)
+                Db, Ab = lut.get_dose_and_derivative_from_spline(xdata[5, :], ydata, row[:, 2], k=k, ext=ext, s=s)
+
             # Remove unphysical values
             Dm[Dm < 0], Dr[Dr < 0], Dg[Dg < 0], Db[Db < 0] = 0, 0, 0, 0
-             
+
             # Store single channel doses
             Dave = (Dr + Dg + Db) / 3
-            dose_m[i,:] = Dm
-            dose_r[i,:] = Dr
-            dose_g[i,:] = Dg
-            dose_b[i,:] = Db
-            dose_ave[i,:] = Dave
-            
+            dose_m[i, :] = Dm
+            dose_r[i, :] = Dr
+            dose_g[i, :] = Dg
+            dose_b[i, :] = Db
+            dose_ave[i, :] = Dave
+
             # Compute terms
             sum_Ak = Ar + Ag + Ab
             sum_Ak2 = Ar**2 + Ag**2 + Ab**2
             sum_DkAk = Dr*Ar + Dg*Ag + Db*Ab
             RS = sum_Ak**2 / sum_Ak2 / 3        # eq. 9
-            
+
             # Compute dose
             dose_temp = ( Dave - RS * sum_DkAk / sum_Ak ) / ( 1 - RS )        # eq. 6
-            
+
             # Remove unphysical values
             dose_temp[dose_temp<0] = 0
-            dose_opt[i,:] = dose_temp
-            
+            dose_opt[i, :] = dose_temp
+
             # Compute disturbance map
-            delta[i,:] = ( (dose_temp-Dr)*Ar + (dose_temp-Dg)*Ag + (dose_temp-Db)*Ab ) / sum_Ak2 # eq. 7
-            
+            delta[i, :] = ( (dose_temp-Dr)*Ar + (dose_temp-Dg)*Ag + (dose_temp-Db)*Ab ) / sum_Ak2  # eq. 7
+
             # Compute residual error (eq. 2)
-            RE[i,:] = (( Dr + Ar*delta[i,:] - dose_opt[i,:] )**2 +
-                      ( Dg + Ag*delta[i,:] - dose_opt[i,:] )**2 + 
-                      ( Db + Ab*delta[i,:] - dose_opt[i,:] )**2 )**0.5
-             
+            RE[i, :] = (
+                ( Dr + Ar*delta[i, :] - dose_opt[i, :] )**2
+                + ( Dg + Ag*delta[i, :] - dose_opt[i, :] )**2
+                + ( Db + Ab*delta[i, :] - dose_opt[i, :] )**2
+            )**0.5
+
         if self.clip is not None:
             dose_m[dose_m > self.clip] = self.clip
             dose_r[dose_r > self.clip] = self.clip
@@ -326,48 +411,77 @@ class Gaf:
             dose_b[dose_b > self.clip] = self.clip
             dose_opt[dose_opt > self.clip] = self.clip
             dose_ave[dose_ave > self.clip] = self.clip
-        
-        self.dose_m = load(dose_m, dpi=self.img.dpi) 
-        self.dose_r = load(dose_r, dpi=self.img.dpi)   
-        self.dose_g = load(dose_g, dpi=self.img.dpi)      
-        self.dose_b = load(dose_b, dpi=self.img.dpi)    
-        self.dose_ave = load(dose_ave, dpi=self.img.dpi)  
-        self.dose_opt = load(dose_opt, dpi=self.img.dpi)   
-        self.dose_opt_delta = load(delta, dpi=self.img.dpi)   
-        self.dose_opt_RE = load(RE, dpi=self.img.dpi)  
-        self.dose_rg = load((dose_r+dose_g)/2., dpi=self.img.dpi)  
-        self.dose_consistency = load(((dose_r-dose_g)**2 + (dose_r-dose_b)**2 + (dose_b-dose_g)**2)**0.5, dpi=self.img.dpi)  
-        
+
+        self.dose_m = load(dose_m, dpi=self.img.dpi)
+        self.dose_r = load(dose_r, dpi=self.img.dpi)
+        self.dose_g = load(dose_g, dpi=self.img.dpi)
+        self.dose_b = load(dose_b, dpi=self.img.dpi)
+        self.dose_ave = load(dose_ave, dpi=self.img.dpi)
+        self.dose_opt = load(dose_opt, dpi=self.img.dpi)
+        self.dose_opt_delta = load(delta, dpi=self.img.dpi)
+        self.dose_opt_RE = load(RE, dpi=self.img.dpi)
+        self.dose_rg = load((dose_r + dose_g)/2., dpi=self.img.dpi)
+        self.dose_consistency = load(
+            ((dose_r - dose_g)**2 + (dose_r - dose_b)**2 + (dose_b - dose_g)**2)**0.5,
+            dpi=self.img.dpi
+        )
+
     def show_results(self, savefile = None, show = True):
-        """ Display a figure with the different converted dose maps and metrics.
+        """
+        Display a figure with the different converted dose maps and metrics.
         """
 
-        max_dose_m = np.percentile(self.dose_m.array,[99.9])[0].round(decimals=-1)
-        max_dose_opt = np.percentile(self.dose_opt.array,[99.9])[0].round(decimals=-1)
-        clim = [0, max(max_dose_m, max_dose_opt)]   
-        fig, ((ax1,ax2,ax3),(ax4,ax5,ax6),(ax7,ax8,ax9)) = plt.subplots(3,3,figsize=(14, 9))
+        max_dose_m = np.percentile(self.dose_m.array, [99.9])[0].round(decimals=-1)
+        max_dose_opt = np.percentile(self.dose_opt.array, [99.9])[0].round(decimals=-1)
+        clim = [0, max(max_dose_m, max_dose_opt)]
+        fig, ((ax1,ax2,ax3), (ax4,ax5,ax6), (ax7,ax8,ax9)) = plt.subplots(3, 3, figsize=(14, 9))
         axes = [ax1, ax2, ax3, ax4, ax5, ax6, ax7, ax8, ax9]
 
-        self.dose_r.plotCB(ax1,clim=clim, title='Red channel dose')
-        self.dose_g.plotCB(ax2,clim=clim, title='Green channel dose')
-        self.dose_b.plotCB(ax3,clim=clim, title='Blue channel dose')
-        self.dose_m.plotCB(ax4,clim=clim, title='Mean channel dose')
-        self.dose_rg.plotCB(ax5,clim=clim, title='Red+Green Average dose')
-        self.dose_consistency.plotCB(ax6, clim = [0, np.percentile(self.dose_consistency.array, [99.5])[0]], cmap='gray', title='Consistency')
-        self.dose_opt.plotCB(ax7,clim=clim, title='Multichannel optimized dose')
-        self.dose_opt_delta.plotCB(ax8, clim = [np.percentile(self.dose_opt_delta.array, [0.5])[0], 
-                                                np.percentile(self.dose_opt_delta.array, [99.5])[0]], cmap='gray', title='Disturbance')
-        self.dose_opt_RE.plotCB(ax9, clim = [0, np.percentile(self.dose_opt_RE.array, [99.5])[0]], cmap='gray', title='Residuals')
-        
+        self.dose_r.plotCB(ax1, clim=clim, title='Red channel dose')
+        self.dose_g.plotCB(ax2, clim=clim, title='Green channel dose')
+        self.dose_b.plotCB(ax3, clim=clim, title='Blue channel dose')
+        self.dose_m.plotCB(ax4, clim=clim, title='Mean channel dose')
+        self.dose_rg.plotCB(ax5, clim=clim, title='Red+Green Average dose')
+
+        self.dose_consistency.plotCB(
+            ax6,
+            clim = [0, np.percentile(self.dose_consistency.array, [99.5])[0]],
+            cmap='gray',
+            title='Consistency'
+        )
+
+        self.dose_opt.plotCB(
+            ax7,
+            clim=clim,
+            title='Multichannel optimized dose'
+        )
+
+        self.dose_opt_delta.plotCB(
+            ax8,
+            clim = [np.percentile(self.dose_opt_delta.array, [0.5])[0],
+                    np.percentile(self.dose_opt_delta.array, [99.5])[0]],
+            cmap='gray',
+            title='Disturbance'
+        )
+
+        self.dose_opt_RE.plotCB(
+            ax9,
+            clim = [0, np.percentile(self.dose_opt_RE.array, [99.5])[0]],
+            cmap='gray',
+            title='Residuals'
+        )
+
         fig.tight_layout()
-        
-        if savefile: plt.savefig(savefile)
-        if show: 
+
+        if savefile:
+            plt.savefig(savefile)
+        if show:
             plt.multi = MultiCursor(None, (axes), color='r', lw=1, horizOn=True)
             plt.show()
-        
+
     def save_analyzed_image(self, filename, **kwargs):
-        """Save the analyzed image to a file.
+        """
+        Save the analyzed image to a file.
 
         Parameters
         ----------
@@ -380,9 +494,10 @@ class Gaf:
         fig = plt.gcf()
         fig.savefig(filename)
         plt.close(fig)
-        
+
     def publish_pdf(self, filename=None, author=None, unit=None, notes=None, open_file=False):
-        """Publish a PDF report of the calibration. The report includes basic
+        """
+        Publish a PDF report of the calibration. The report includes basic
         file information, the image and determined ROIs, and the calibration curves
 
         Parameters
@@ -400,102 +515,110 @@ class Gaf:
             Whether or not to open the PDF file after it is created.
             Default is False.
         """
-        if filename is None: filename = os.path.join(self.path, 'Report.pdf')
+        if filename is None:
+            filename = os.path.join(self.path, 'Report.pdf')
         title='Film-to-Dose Report'
         # canvas = pdf.create_pylinac_page_template(filename, analysis_title=title)
-        canvas = pdf.PylinacCanvas(filename, page_title=title, logo=Path(__file__).parent / 'OMG_Logo.png')
-        
+        canvas = pdf.PylinacCanvas(
+            filename,
+            page_title=title,
+            logo=Path(__file__).parent / 'OMG_Logo.png'
+        )
+
         data = io.BytesIO()
         self.save_analyzed_image(data, show = False)
         canvas.add_image(image_data=data, location=(0.5, 2), dimensions=(20, 20))
         canvas.add_text(text='Film infos:', location=(1, 25.5), font_size=12)
-        text = ['Author: {}'.format(self.info['author']),
-                'Unit: {}'.format(self.info['unit']),
-                'Film lot: {}'.format(self.info['film_lot']),
-                'Scanner ID: {}'.format(self.info['scanner_id']),
-                'Date exposed: {}'.format(self.info['date_exposed']),
-                'Date scanned: {}'.format(self.info['date_scanned']),
-                'Wait time: {}'.format(self.info['wait_time']),
-               ]
+        text = [
+            'Author: {}'.format(self.info['author']),
+            'Unit: {}'.format(self.info['unit']),
+            'Film lot: {}'.format(self.info['film_lot']),
+            'Scanner ID: {}'.format(self.info['scanner_id']),
+            'Date exposed: {}'.format(self.info['date_exposed']),
+            'Date scanned: {}'.format(self.info['date_scanned']),
+            'Wait time: {}'.format(self.info['wait_time']),
+        ]
         canvas.add_text(text=text, location=(1, 25), font_size=10)
         canvas.add_text(text='Conversion options:', location=(1, 21.5), font_size=12)
-        text = ['Film file: {}'.format(os.path.basename(self.filename)),
-                'LUT file: {}'.format(os.path.basename(self.lut_file)),
-                'Film filter kernel: {}'.format(self.img_filt),
-                'LUT filter kernel: {}'.format(self.lut_filt),
-                'LUT fit: {}'.format(self.fit_type),
-               ]    
+        text = [
+            'Film file: {}'.format(os.path.basename(self.filename)),
+            'LUT file: {}'.format(os.path.basename(self.lut_file)),
+            'Film filter kernel: {}'.format(self.img_filt),
+            'LUT filter kernel: {}'.format(self.lut_filt),
+            'LUT fit: {}'.format(self.fit_type),
+        ]
         canvas.add_text(text=text, location=(1, 21), font_size=10)
-        
+
         if self.info['notes'] != '':
             canvas.add_text(text='Notes:', location=(1, 2.5), font_size=14)
             canvas.add_text(text=self.info['notes'], location=(1, 2), font_size=14)
         canvas.finish()
-        if open_file: webbrowser.open(filename)
-    
+        if open_file:
+            webbrowser.open(filename)
+
     # def apply_factor_from_roi(self, norm_dose = None):
     #     """ Define an ROI on an unexposed film to correct for scanner response. """
-        
+
     #     msg = 'Factor from ROI: Click and drag to draw an ROI manually. Press ''enter'' when finished.'
     #     self.roi_xmin = []
     #     self.roi_xmax = []
     #     self.roi_ymin = []
     #     self.roi_ymax = []
-        
+
     #     self.fig = plt.figure()
-    #     ax = plt.gca()  
-    #     self.img.plot(ax=ax)  
+    #     ax = plt.gca()
+    #     self.img.plot(ax=ax)
     #     ax.plot((0,self.img.shape[1]),(self.img.center.y,self.img.center.y),'k--')
     #     ax.set_xlim(0, self.img.shape[1])
     #     ax.set_ylim(self.img.shape[0],0)
     #     ax.set_title(msg)
     #     print(msg)
-        
+
     #     def select_box(eclick, erelease):
     #         ax = plt.gca()
     #         x1, y1 = int(eclick.xdata), int(eclick.ydata)
     #         x2, y2 = int(erelease.xdata), int(erelease.ydata)
     #         rect = plt.Rectangle( (min(x1,x2),min(y1,y2)), np.abs(x1-x2), np.abs(y1-y2), Fill=False )
-    #         ax.add_patch(rect)           
+    #         ax.add_patch(rect)
     #         self.roi_xmin = min(x1,x2)
     #         self.roi_xmax = max(x1,x2)
     #         self.roi_ymin = min(y1,y2)
     #         self.roi_ymax = max(y1,y2)
-        
-    #     self.rs = RectangleSelector(ax, select_box, drawtype='box', useblit=False, button=[1], 
-    #                                 minspanx=5, minspany=5, spancoords='pixels', interactive=True)    
+
+    #     self.rs = RectangleSelector(ax, select_box, drawtype='box', useblit=False, button=[1],
+    #                                 minspanx=5, minspany=5, spancoords='pixels', interactive=True)
     #     self.cid = self.fig.canvas.mpl_connect('key_press_event', self.apply_factor_from_roi_press_enter)
-        
+
     #     self.wait = True
     #     while self.wait: plt.pause(5)
     #     return
-        
+
     # def apply_factor_from_roi_press_enter(self, event):
-    #     """ Continue when ''enter'' is pressed. """      
+    #     """ Continue when ''enter'' is pressed. """
     #     if event.key == 'enter':
     #         # Get ROIs values
     #         roi_R = np.median(self.img.array[self.roi_ymin:self.roi_ymax, self.roi_xmin:self.roi_xmax, 0])
     #         roi_G = np.median(self.img.array[self.roi_ymin:self.roi_ymax, self.roi_xmin:self.roi_xmax, 1])
     #         roi_B = np.median(self.img.array[self.roi_ymin:self.roi_ymax, self.roi_xmin:self.roi_xmax, 2])
-            
+
     #         # Unexposed film from calibration
     #         calib_R = self.lut.channel_R[0]
     #         calib_G = self.lut.channel_G[0]
     #         calib_B = self.lut.channel_B[0]
-            
+
     #         # Compute factors
     #         self.scale_R = calib_R / roi_R
     #         self.scale_G = calib_G / roi_G
     #         self.scale_B = calib_B / roi_B
-            
+
     #         # Apply scaling
     #         self.img.array[:,:,0] = self.img.array[:,:,0] * self.scale_R
     #         self.img.array[:,:,1] = self.img.array[:,:,1] * self.scale_G
     #         self.img.array[:,:,2] = self.img.array[:,:,2] * self.scale_B
-            
-    #         del self.rs                
+
+    #         del self.rs
     #         self.fig.canvas.mpl_disconnect(self.cid)
-    #         plt.close(self.fig)   
+    #         plt.close(self.fig)
     #         self.wait = False
     #         return
 
@@ -505,7 +628,7 @@ def rational_func(x, a, b, c):
 
 
 def drational_func(x, a, b, c):
-    return -b/(x-a)**2
+    return -b /(x-a)**2
 
 
 def save_dose(dose, filename):

--- a/src/omg_dosimetry/tiff2dose.py
+++ b/src/omg_dosimetry/tiff2dose.py
@@ -324,10 +324,7 @@ class Gaf:
         # Apply median filter on all image channels if needed
         if img_filt:
             for i in range(0, 3):
-                img.array[:, :, i] = medfilt(
-                    img.array[:, :, i],
-                    kernel_size=(img_filt, img_filt)
-                )
+                img.array[:, :, i] = medfilt(img.array[:, :, i],kernel_size=(img_filt, img_filt))
 
         # Apply median filter on LUT if needed
         if lut_filt:
@@ -362,11 +359,7 @@ class Gaf:
                 ydata = p_lut[1]
 
             if fit_type == 'rational':
-                Dm, Am = lut.get_dose_and_derivative_from_fit(
-                    xdata[2, :],
-                    ydata,
-                    np.mean(row, axis=-1)
-                )
+                Dm, Am = lut.get_dose_and_derivative_from_fit(xdata[2, :],ydata,np.mean(row, axis=-1))
                 Dr, Ar = lut.get_dose_and_derivative_from_fit(xdata[3, :], ydata, row[:, 0])
                 Dg, Ag = lut.get_dose_and_derivative_from_fit(xdata[4, :], ydata, row[:, 1])
                 Db, Ab = lut.get_dose_and_derivative_from_fit(xdata[5, :], ydata, row[:, 2])
@@ -405,11 +398,9 @@ class Gaf:
             delta[i, :] = ( (dose_temp-Dr)*Ar + (dose_temp-Dg)*Ag + (dose_temp-Db)*Ab ) / sum_Ak2  # eq. 7
 
             # Compute residual error (eq. 2)
-            RE[i, :] = (
-                ( Dr + Ar*delta[i, :] - dose_opt[i, :] )**2
-                + ( Dg + Ag*delta[i, :] - dose_opt[i, :] )**2
-                + ( Db + Ab*delta[i, :] - dose_opt[i, :] )**2
-            )**0.5
+            RE[i, :] = (( Dr + Ar*delta[i, :] - dose_opt[i, :] )**2 +
+                ( Dg + Ag*delta[i, :] - dose_opt[i, :] )**2 + 
+                ( Db + Ab*delta[i, :] - dose_opt[i, :] )**2 )**0.5
 
         if self.clip is not None:
             dose_m[dose_m > self.clip] = self.clip

--- a/src/omg_dosimetry/tiff2dose.py
+++ b/src/omg_dosimetry/tiff2dose.py
@@ -17,8 +17,8 @@ Features:
     - Publish PDF report
         
 Written by Jean-Francois Cabana, copyright 2018
-Modified by Peter Truong (CISSSO)
-Version: 2023-12-06
+Modified by Peter Truong (CISSSO) and Luis Alfonso Olivares Jimenez
+Version: 2023-12-26
 """
 
 import os
@@ -168,7 +168,7 @@ class Gaf:
         retrieve_demo_file("A1A_Multi_6cm_001.tif")
 
         # Folder containing scanned image
-        demo_path = Path(__file__).parent / "demo_files" / "tiff2dose"      
+        demo_path = Path(__file__).parent / "demo_files" / "tiff2dose" / "scan"
         
         # Name of the output file to produce
         outname = "Demo_dose"
@@ -186,7 +186,7 @@ class Gaf:
         gaf1 = Gaf(path = demo_path, lut_file=lut_file, fit_type=fit_type, info=info, clip = clip)
 
         # Save dose and PDF report
-        filename_tif = demo_path / str(outname + ".tif")
+        filename_tif = demo_path.parent / str(outname + ".tif")
 
         # We save the optimized dose (dose_opt). Other options include individual channels 
         # (dose_r, dose_g, dose_b) and individual channels doses average (dose_ave).

--- a/src/omg_dosimetry/tiff2dose.py
+++ b/src/omg_dosimetry/tiff2dose.py
@@ -17,8 +17,10 @@ Features:
     - Output metrics for evaluation of dose conversion quality: disturbance map, residual error, consistency map
     - Publish PDF report
 
-Written by Jean-Francois Cabana, copyright 2018
-Modified by Peter Truong (CISSSO) and Luis Alfonso Olivares Jimenez
+Written by Jean-Francois Cabana, copyright 2018.
+
+Modified by Peter Truong (CISSSO) and Luis Alfonso Olivares Jimenez.
+
 Version: 2024-01-03
 """
 
@@ -196,8 +198,14 @@ class Gaf:
             self.dose_consistency.crop_edges(threshold=crop_edges)
 
     @staticmethod
-    def run_demo() -> None:
-        """Run the Gaf demo by loading the demo image and print results."""
+    def run_demo(show = True) -> None:
+        """Run the Gaf demo by loading the demo image and print results.
+
+        Parameters
+        ----------
+        show : bools
+            Display a summary of the results.
+        """
 
         # Define general information
         info = dict(
@@ -221,10 +229,7 @@ class Gaf:
         # outname = "Demo_dose"
 
         # Path to LUT film to use
-        lut_file = Path(__file__).parent / "demo_files" / "calibration" / "Demo_calib.pkl"
-        if not lut_file.exists():
-            print("Running LUT.run_demo()...")
-            LUT.run_demo(show=False)
+        lut_file = from_demo_lut()
 
         # Function type used for fitting calibration curve. 'rational' (recommended)
         # or 'spline'
@@ -253,7 +258,8 @@ class Gaf:
         # filename_pdf = demo_path / str(outname + ".pdf")
         # gaf1.publish_pdf(str(filename_pdf), open_file=True)
 
-        gaf1.show_results(io.BytesIO(), show=True)
+        if show:
+            gaf1.show_results(io.BytesIO())
 
     def load_files(self, path):
         """
@@ -312,7 +318,8 @@ class Gaf:
 
         # Check that image and LUT sizes match (if lateral correction is used)
         if lut.lateral_correction:
-            raise ValueError("Image dimension does not match LUT resolution!")
+            if ysize != lut.npixel:
+                raise ValueError("Image dimension does not match LUT resolution!")
 
         # Apply median filter on all image channels if needed
         if img_filt:
@@ -647,3 +654,14 @@ def from_demo_image() -> Path:
 
     img = retrieve_demo_file("A1A_Multi_6cm_001.tif")
     return img.parent
+
+
+def from_demo_lut() -> Path:
+    """Load the demo lut and return the path to the file."""
+
+    lut_file_path = Path(__file__).parent / "demo_files" / "calibration" / "Demo_calib.pkl"
+    if not lut_file_path.exists():
+        print("Running LUT.run_demo()...")
+        LUT.run_demo(show=False)
+
+    return lut_file_path

--- a/src/omg_dosimetry/tiff2dose.py
+++ b/src/omg_dosimetry/tiff2dose.py
@@ -33,6 +33,7 @@ import webbrowser
 from pathlib import Path
 from .imageRGB import load, load_multiples
 from .calibration import load_lut
+from .i_o import retrieve_demo_file
 
 class Gaf:
     """Base class for gafchromic films converted to dose.
@@ -143,6 +144,52 @@ class Gaf:
             self.dose_opt_RE.crop_edges(threshold=crop_edges)
             self.dose_rg.crop_edges(threshold=crop_edges)
             self.dose_consistency.crop_edges(threshold=crop_edges)
+
+    @staticmethod
+    def run_demo(film_detect = True) -> None:
+        """Run the Gaf demo by loading the demo image and print results."""
+
+        # Define general information
+        info = dict(author = 'Demo Physicist',
+            unit = 'Demo Linac',
+            film_lot = 'XD_1',
+            scanner_id = 'Epson 72000XL',
+            date_exposed = '2023-01-24 16h',
+            date_scanned = '2023-01-25 16h',
+            wait_time = '24 hours',
+            notes = 'Transmission mode, @300ppp and 16 bits/channel'
+           )
+
+        # Download demo tif files and save it on demo_files folder.
+        retrieve_demo_file("A1A_Multi_6cm_001.tif")
+
+        # Folder containing scanned image
+        demo_path = Path(__file__).parent / "demo_files"       
+        
+        # Name of the output file to produce
+        outname = "Demo_dose"
+
+        # Path to LUT film to use
+        lut_file = Path(__file__).parent / "demo_files" / "Demo_calib.pkl"
+
+        # Function type used for fitting calibration curve. 'rational' (recommended) or 'spline'
+        fit_type = 'rational'
+
+        # Maximum value [cGy] to limit dose. Useful to avoid very high doses obtained due to markings on the film.
+        clip = 500
+
+        # Perform dose conversion
+        gaf1 = Gaf(path = demo_path, lut_file=lut_file, fit_type=fit_type, info=info, clip = clip)
+
+        # Save dose and PDF report
+        #filename_tif = demo_path / outname / '.tif'
+
+        # We save the optimized dose (dose_opt). Other options include individual channels 
+        # (dose_r, dose_g, dose_b) and individual channels doses average (dose_ave).
+        #gaf1.dose_opt.save(filename_tif)
+
+        #filename_pdf = demo_path / outname / '.pdf'
+        #gaf1.publish_pdf(filename_pdf, open_file=True)
 
     def load_files(self, path):
         """ Load image files found in path. 

--- a/src/omg_dosimetry/tiff2dose.py
+++ b/src/omg_dosimetry/tiff2dose.py
@@ -327,10 +327,7 @@ class Gaf:
             if lut.lateral_correction:
                 for i in range(0, len(lut.doses)):  # loop over all doses
                     for j in range(2, 6):  # loop over all channels (mean, R, G, B)
-                        lut.lut[j, i, :] = medfilt(
-                            lut.lut[j, i, :],
-                            kernel_size=(lut_filt)
-                        )
+                        lut.lut[j, i, :] = medfilt(lut.lut[j, i, :], kernel_size=(lut_filt))
             else:
                 pass
 
@@ -351,6 +348,7 @@ class Gaf:
                 p_lut = lut.lut[:, :, i]
                 xdata = p_lut[:, :]
                 ydata = p_lut[1, :]
+
             else:
                 p_lut = lut.lut[:, :]
                 xdata = p_lut[:]
@@ -358,12 +356,14 @@ class Gaf:
 
             if fit_type == 'rational':
                 Dm, Am = lut.get_dose_and_derivative_from_fit(
-                    xdata[2, :], ydata,
+                    xdata[2, :],
+                    ydata,
                     np.mean(row, axis=-1)
                 )
                 Dr, Ar = lut.get_dose_and_derivative_from_fit(xdata[3, :], ydata, row[:, 0])
                 Dg, Ag = lut.get_dose_and_derivative_from_fit(xdata[4, :], ydata, row[:, 1])
                 Db, Ab = lut.get_dose_and_derivative_from_fit(xdata[5, :], ydata, row[:, 2])
+
             elif fit_type == 'spline':
                 Dm, Am = lut.get_dose_and_derivative_from_spline(xdata[2, :], ydata, np.mean(row, axis=-1), k=k, ext=ext, s=s)
                 Dr, Ar = lut.get_dose_and_derivative_from_spline(xdata[3, :], ydata, row[:, 0], k=k, ext=ext, s=s)
@@ -628,7 +628,7 @@ def rational_func(x, a, b, c):
 
 
 def drational_func(x, a, b, c):
-    return -b /(x-a)**2
+    return -b/(x-a)**2
 
 
 def save_dose(dose, filename):

--- a/src/omg_dosimetry/tiff2dose.py
+++ b/src/omg_dosimetry/tiff2dose.py
@@ -640,3 +640,10 @@ def save_dose(dose, filename):
 def load_dose(filename):
     with open(filename, 'rb') as input:
         return pickle.load(input)
+
+
+def from_demo_image() -> Path:
+    """Load the demo images and return the path to the content folder."""
+
+    img = retrieve_demo_file("A1A_Multi_6cm_001.tif")
+    return img.parent

--- a/src/omg_dosimetry/tiff2dose.py
+++ b/src/omg_dosimetry/tiff2dose.py
@@ -31,9 +31,13 @@ import io
 from matplotlib.widgets  import RectangleSelector, MultiCursor
 import webbrowser
 from pathlib import Path
-from .imageRGB import load, load_multiples
-from .calibration import load_lut
-from .i_o import retrieve_demo_file
+#from .imageRGB import load, load_multiples
+#from .calibration import load_lut
+#from .i_o import retrieve_demo_file
+
+from imageRGB import load, load_multiples
+from calibration import load_lut
+from i_o import retrieve_demo_file
 
 class Gaf:
     """Base class for gafchromic films converted to dose.
@@ -146,7 +150,7 @@ class Gaf:
             self.dose_consistency.crop_edges(threshold=crop_edges)
 
     @staticmethod
-    def run_demo(film_detect = True) -> None:
+    def run_demo() -> None:
         """Run the Gaf demo by loading the demo image and print results."""
 
         # Define general information
@@ -164,13 +168,13 @@ class Gaf:
         retrieve_demo_file("A1A_Multi_6cm_001.tif")
 
         # Folder containing scanned image
-        demo_path = Path(__file__).parent / "demo_files"       
+        demo_path = Path(__file__).parent / "demo_files" / "tiff2dose"      
         
         # Name of the output file to produce
         outname = "Demo_dose"
 
         # Path to LUT film to use
-        lut_file = Path(__file__).parent / "demo_files" / "Demo_calib.pkl"
+        lut_file = Path(__file__).parent / "demo_files" / "calibration" / "Demo_calib.pkl"
 
         # Function type used for fitting calibration curve. 'rational' (recommended) or 'spline'
         fit_type = 'rational'
@@ -182,14 +186,14 @@ class Gaf:
         gaf1 = Gaf(path = demo_path, lut_file=lut_file, fit_type=fit_type, info=info, clip = clip)
 
         # Save dose and PDF report
-        #filename_tif = demo_path / outname / '.tif'
+        filename_tif = demo_path / str(outname + ".tif")
 
         # We save the optimized dose (dose_opt). Other options include individual channels 
         # (dose_r, dose_g, dose_b) and individual channels doses average (dose_ave).
-        #gaf1.dose_opt.save(filename_tif)
+        gaf1.dose_opt.save(filename_tif)
 
-        #filename_pdf = demo_path / outname / '.pdf'
-        #gaf1.publish_pdf(filename_pdf, open_file=True)
+        filename_pdf = demo_path / str(outname + ".pdf")
+        gaf1.publish_pdf(str(filename_pdf), open_file=True)
 
     def load_files(self, path):
         """ Load image files found in path. 

--- a/src/omg_dosimetry/tiff2dose.py
+++ b/src/omg_dosimetry/tiff2dose.py
@@ -399,8 +399,8 @@ class Gaf:
 
             # Compute residual error (eq. 2)
             RE[i, :] = (( Dr + Ar*delta[i, :] - dose_opt[i, :] )**2 +
-                ( Dg + Ag*delta[i, :] - dose_opt[i, :] )**2 + 
-                ( Db + Ab*delta[i, :] - dose_opt[i, :] )**2 )**0.5
+                        ( Dg + Ag*delta[i, :] - dose_opt[i, :] )**2 + 
+                        ( Db + Ab*delta[i, :] - dose_opt[i, :] )**2 )**0.5
 
         if self.clip is not None:
             dose_m[dose_m > self.clip] = self.clip

--- a/src/omg_dosimetry/tiff2dose.py
+++ b/src/omg_dosimetry/tiff2dose.py
@@ -35,9 +35,6 @@ from .imageRGB import load, load_multiples
 from .calibration import load_lut, LUT
 from .i_o import retrieve_demo_file
 
-#from imageRGB import load, load_multiples
-#from calibration import load_lut, LUT
-#from i_o import retrieve_demo_file
 
 class Gaf:
     """Base class for gafchromic films converted to dose.
@@ -502,16 +499,20 @@ class Gaf:
     #         self.wait = False
     #         return
 
+
 def rational_func(x, a, b, c):
     return -c + b/(x-a)
 
+
 def drational_func(x, a, b, c):
     return -b/(x-a)**2
+
 
 def save_dose(dose, filename):
     dose.filename = filename
     with open(filename, 'wb') as output:
         pickle.dump(dose, output, pickle.HIGHEST_PROTOCOL)
+
 
 def load_dose(filename):
     with open(filename, 'rb') as input:

--- a/src/omg_dosimetry/tiff2dose.py
+++ b/src/omg_dosimetry/tiff2dose.py
@@ -36,7 +36,7 @@ from pathlib import Path
 #from .i_o import retrieve_demo_file
 
 from imageRGB import load, load_multiples
-from calibration import load_lut
+from calibration import load_lut, LUT
 from i_o import retrieve_demo_file
 
 class Gaf:
@@ -150,7 +150,7 @@ class Gaf:
             self.dose_consistency.crop_edges(threshold=crop_edges)
 
     @staticmethod
-    def run_demo() -> None:
+    def run_demo(show=True) -> None:
         """Run the Gaf demo by loading the demo image and print results."""
 
         # Define general information
@@ -175,6 +175,9 @@ class Gaf:
 
         # Path to LUT film to use
         lut_file = Path(__file__).parent / "demo_files" / "calibration" / "Demo_calib.pkl"
+        if not lut_file.exists():
+            print("Running LUT.run_demo()...")
+            LUT.run_demo(show=False)
 
         # Function type used for fitting calibration curve. 'rational' (recommended) or 'spline'
         fit_type = 'rational'
@@ -191,6 +194,8 @@ class Gaf:
         # We save the optimized dose (dose_opt). Other options include individual channels 
         # (dose_r, dose_g, dose_b) and individual channels doses average (dose_ave).
         gaf1.dose_opt.save(filename_tif)
+
+        gaf1.show_results(io.BytesIO(), show=show)
 
         filename_pdf = demo_path / str(outname + ".pdf")
         gaf1.publish_pdf(str(filename_pdf), open_file=True)


### PR DESCRIPTION
Hi,
These are some additions for ReadTheDocs documentation,

**calibration.rst:**

* Full path to import LUT. I think it is a little better to see where the LUT class comes from when it is imported.
* A note for supported tiff images.

**conf.py:**

* Add links to **highlighted source code** in *API Documentation* section (sphinx extension viewcode)

**tiff2dose.rst:**

* New run demo and usage sections.

**calibration.py:**

* New *show* parameter in run_demo() to manage a call to show_results()
* New path location for loaded demo tiff files 

**i_o.py:**

* New url paths used to automatically download demo files when run_demo() is called from calibration, tiff2dose or analysis modules.

**tiff2dose.py:**

* Application of [PEP 8](https://peps.python.org/pep-0008/) to follow style code conventions to improve the readability of code (application of [flake8](https://flake8.pycqa.org/en/latest/))
* New run_demo() method. It is intended to be used as a fast demonstration for new users, and also as a tool to **test** the module after changes in the source code. It is almost a copy from scripts/demo/omg_tiff2dose_demo.py.
* *Parameters* and *instance attributes* from Gaf class were discriminated in the docstring.
* New "from_demo_image()" function. Used to load a demo image.
* New "from_demo_lut()" function. Used to load a demo LUT.

Happy new year 😃 🎇.
Luis