### PR TITLE
Related to issue #38

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -58,6 +58,7 @@ jobs:
     name: >-
       Sign the Python 🐍 distribution 📦 with Sigstore
       and upload them to GitHub Release
+    if: startsWith(github.ref, 'refs/tags/')  # A new release is created only if the pull request merge branch has a tag.
     needs:
     - publish-to-pypi
     runs-on: ubuntu-latest

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,7 @@ author = 'Jean-François Cabana, Luis Alfonso Olivares Jiménez and Peter Truong
 # The short X.Y version.
 version = "1.6"
 # The full version, including alpha/beta/rc tags.
-release = "1.6.2"
+release = "1.6.3"
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "omg_dosimetry"
 
-version = "1.6.2"
+version = "1.6.3"
 
 authors = [
   { name="JF Cabana", email="jean-francois.cabana.cisssca@ssss.gouv.qc.ca" },


### PR DESCRIPTION
A new line of code to automatically create a new release on GutHub **only if** the pull request merge branch has a tag.
To test, the branch "issue_action_workflow" (from where I am opening this pull request) has a tag on it.