### PR TITLE
New discard_small_clusters()

### DIFF
--- a/src/omg_dosimetry/imageRGB.py
+++ b/src/omg_dosimetry/imageRGB.py
@@ -20,6 +20,7 @@ import numpy as np
 from PIL import Image as pImage
 from scipy import ndimage
 from skimage.transform import rotate
+from skimage.measure import regionprops
 import scipy.ndimage.filters as spf
 
 from pylinac.core.utilities import is_close
@@ -405,8 +406,31 @@ class BaseImage:
             cluster['center_of_mass'] = np.mean(cluster['coords'], axis=0)
             clusters.append(cluster)
         self.clusters = clusters
-        return clusters    
-    
+        return clusters
+
+    def discard_small_clusters(self, minimum_length):
+        """
+        Discard cluster with an axis_minor_length less than a given value.
+
+        Parameters
+        ----------
+        minimum_length : float
+            The minimum length in milimeters for retaining clusters.
+        """    
+        new_clusters = []
+        # Calculate the size threshold in pixels
+        size_threshold = minimum_length*self.dpmm
+
+        for region in self.clusters:
+            if region['coords'].shape[0] == 1: # Skip one pixel size clusters.
+                pass
+            region_prop = regionprops(region['region_mask'].astype(int))
+            if region_prop[0]['axis_minor_length'] < size_threshold:
+                pass
+            else:
+                new_clusters.append(region)
+        self.clusters = new_clusters
+
     def plot_clusters(self):
         self.plot()
         for cluster in self.clusters:


### PR DESCRIPTION
Added `discard_small_clusters()` method in BaseImage class to remove small clusters.

Additionally, I have noticed that `plot()` method form BaseImage now uses origin='upper', but `plot_clusters()` does not. Below is an example of the output figure when plot_clusters() is called. As can be seen, the image and the scatter are inverted.

Script example:
```python
from omg_dosimetry.tiff2dose import Gaf
from omg_dosimetry import tiff2dose
import matplotlib.pyplot as plt

# Load demo LUT
path_to_lut_file = tiff2dose.from_demo_lut()

# Load folder to demo tif file
path_to_tif_folder = tiff2dose.from_demo_image()

# Gaf init.
fit_type = 'rational'
clip = 500
gaf = Gaf(
    path_to_tif_folder,
    lut_file=path_to_lut_file,
    fit_type=fit_type,
    clip=clip,
    img_filt=3,
    crop_edges=0.1,
)

clusters = gaf.dose_opt.detect_clusters()

print(len(gaf.dose_opt.clusters))  # 388
gaf.dose_opt.discard_small_clusters(minimum_length=2)
print(len(gaf.dose_opt.clusters))  # 13

gaf.dose_opt.plot_clusters()
```
![Screenshot from 2024-05-09 13-04-48](https://github.com/jfcabana/omg_dosimetry/assets/41806420/4739f600-f04c-4f78-91ba-4dd4bef5cb4d)
