### PR TITLE
Related to issue #53 ROI selection

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,7 @@ author = 'Jean-François Cabana, Luis Alfonso Olivares Jiménez and Peter Truong
 # The short X.Y version.
 version = "1.7"
 # The full version, including alpha/beta/rc tags.
-release = "1.7.0"
+release = "1.7.1"
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "omg_dosimetry"
 
-version = "1.7.0"
+version = "1.7.1"
 
 authors = [
   { name="JF Cabana", email="jean-francois.cabana.cisssca@ssss.gouv.qc.ca" },

--- a/src/omg_dosimetry/calibration.py
+++ b/src/omg_dosimetry/calibration.py
@@ -387,28 +387,57 @@ class LUT:
         ax.plot((0,self.img.shape[1]),(self.img.center.y,self.img.center.y),'k--')
         ax.set_xlim(0, self.img.shape[1])
         ax.set_ylim(self.img.shape[0],0)
-        ax.set_title('Click and drag to draw ROIs manually. Press ''enter'' when finished.')
-        print('Click and drag to draw ROIs manually. Press ''enter'' when finished.')
-        
-        def select_box(eclick, erelease):
+        ax.set_title('Click and drag to draw ROIs manually.\n Press ''c'' to catch the ROI and ''enter'' when finished.')
+        print('Click and drag to draw ROIs manually.\n Press ''c'' to catch the ROI and ''enter'' when finished.')
+
+
+        def print_roi_size(eclick, erelease):
             ax = plt.gca()
             x1, y1 = int(eclick.xdata), int(eclick.ydata)
             x2, y2 = int(erelease.xdata), int(erelease.ydata)
-            rect = plt.Rectangle( (min(x1,x2),min(y1,y2)), np.abs(x1-x2), np.abs(y1-y2), fill=True )
-            ax.add_patch(rect) 
-            plt.gcf().canvas.draw_idle()
-            
-            self.roi_xmin.append(min(x1,x2))
-            self.roi_xmax.append(max(x1,x2))
-            self.roi_xpos.append(min(x1,x2) + int(np.floor(np.abs(x1-x2)/2)))
-            self.roi_ymin.append(min(y1,y2))
-            self.roi_ymax.append(max(y1,y2))
-            self.roi_ypos.append(min(y1,y2) + int(np.floor(np.abs(y1-y2)/2)))
-            self.roi_width.append(int(np.abs(x1-x2)))
-            self.roi_length.append(int(np.abs(y1-y2)))
-        
-        self.rs = RectangleSelector(ax, select_box, useblit=True, button=[1], minspanx=5, minspany=5, spancoords='pixels', interactive=True)
+
+            print(f"ROI size (width, height) mm: ({np.abs(x1-x2)/self.img.dpmm:.1f}, {np.abs(y1-y2)/self.img.dpmm:.1f})")
+
+
+        def key_c_pressed(event):
+            """ Create a ROI when 'c' is pressed."""            
+            if event.key in ['c', 'C']:
+                ax = plt.gca()
+                xmin, xmax, ymin, ymax = map(int, self.rs.extents)
+                rect = plt.Rectangle(
+                    (xmin,ymin),
+                    xmax-xmin,
+                    ymax-ymin,
+                    fill=True,
+                    facecolor='red',
+                    edgecolor='black',
+                    alpha=0.5)
+                ax.add_patch(rect)
+                plt.gcf().canvas.draw_idle()
+
+                self.roi_xmin.append(xmin)
+                self.roi_xmax.append(xmax)
+                self.roi_xpos.append(xmin + int(np.floor((xmax-xmin)/2)))
+                self.roi_ymin.append(ymin)
+                self.roi_ymax.append(ymax)
+                self.roi_ypos.append(ymin + int(np.floor((ymax-ymin)/2)))
+                self.roi_width.append(xmax-xmin)
+                self.roi_length.append(ymax-ymin)
+
+        self.rs = RectangleSelector(
+            ax,
+            onselect=print_roi_size,
+            useblit=True,
+            button=[1],
+            minspanx=5,
+            minspany=5,
+            spancoords='pixels',
+            interactive=True,
+            drag_from_anywhere=True,
+            props=dict(facecolor='red', edgecolor='black', alpha=0.4),
+            )
         plt.gcf().canvas.mpl_connect('key_press_event', self.press_enter)
+        plt.gcf().canvas.mpl_connect('key_press_event', key_c_pressed)
         self.wait = True
         plt.show()  
         while self.wait:    # This while is ejecuted only in interactive mode. press_enter changes self.wait to False 


### PR DESCRIPTION
Here are the additions:

1. Adding a new callback function (key_c_pressed) to catch a ROI when the key ```c``` is pressed. 
2. The ROI size (in mm) is shown in the terminal when RectangleSelector changes.
3. New style for RectangleSelector.

The code I used for tesitng (in Anaconda Powershell) was:

```python
from omg_dosimetry.calibration import LUT
from pathlib import Path
import matplotlib.pyplot as plt
from omg_dosimetry import calibration

my_path = calibration.from_demo_image()
doses = [0.0, 100.0, 200.0, 400.0, 650.0, 950.0]

lut = LUT(my_path, doses, crop_top_bottom = 650, film_detect=False) 
```

![roi](https://github.com/jfcabana/omg_dosimetry/assets/41806420/a1f2f4f8-ad80-4bc1-bf13-5ea3c0b24bee)
